### PR TITLE
Refactor to React frontend and API backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Issue Tracker Prototype
+
+This project is a simple issue tracker with a **Node.js** API backend and a **React** frontend. Data is stored in memory for now so you can test functionality without a database. You can later swap in a real database.
+
+## Features
+
+- User registration and login (no sessions yet)
+- Create, view, update issues
+- Assign users and change status
+- Comment on issues
+- Pagination for issue list
+- React-based frontend separated from the backend
+
+## Getting Started
+
+### Backend
+
+1. Install dependencies (requires internet access):
+   ```bash
+   npm install
+   ```
+2. Start the API server:
+   ```bash
+   npm start
+   ```
+
+### Frontend
+
+1. In the `client` directory run:
+   ```bash
+   npm install
+   npm start
+   ```
+   This starts a React development server on port 3001.
+2. Navigate to `http://localhost:3001` to use the app.
+
+## Future Improvements
+
+- Replace the in-memory store with a database (e.g., MongoDB or an RDBMS)
+- Add proper authentication sessions
+- Support file attachments
+- Issue labels and search
+- Email notifications
+

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "issue-tracker-client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "npx serve -s public",
+    "build": "echo build step placeholder"
+  }
+}

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Issue Tracker</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="../src/index.js"></script>
+</body>
+</html>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,0 +1,20 @@
+export default function App() {
+  const [issues, setIssues] = React.useState([]);
+
+  React.useEffect(() => {
+    fetch('/api/issues')
+      .then(res => res.json())
+      .then(data => setIssues(data.issues || []));
+  }, []);
+
+  return (
+    React.createElement('div', null,
+      React.createElement('h1', null, 'Issues'),
+      React.createElement('ul', null,
+        issues.map(i =>
+          React.createElement('li', { key: i.id }, `${i.title} - ${i.status}`)
+        )
+      )
+    )
+  );
+}

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,0 +1,5 @@
+import React from 'https://unpkg.com/react@18/umd/react.development.js?module';
+import ReactDOM from 'https://unpkg.com/react-dom@18/umd/react-dom.development.js?module';
+import App from './App.js';
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "issuetracker-co",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+header { display: flex; justify-content: space-between; align-items: center; }
+nav a { margin-right: 10px; }
+input, textarea, select { display: block; margin-bottom: 10px; }

--- a/src/data/inMemoryStore.js
+++ b/src/data/inMemoryStore.js
@@ -1,0 +1,56 @@
+class InMemoryStore {
+  constructor() {
+    this.users = []; // { id, username, password }
+    this.issues = []; // { id, title, description, status, assignee, comments }
+    this.nextIssueId = 1;
+    this.nextUserId = 1;
+  }
+
+  addUser(username, password) {
+    const user = { id: this.nextUserId++, username, password };
+    this.users.push(user);
+    return user;
+  }
+
+  findUser(username) {
+    return this.users.find(u => u.username === username);
+  }
+
+  addIssue(data) {
+    const issue = {
+      id: this.nextIssueId++,
+      title: data.title,
+      description: data.description,
+      status: data.status || 'open',
+      assignee: data.assignee || null,
+      comments: []
+    };
+    this.issues.push(issue);
+    return issue;
+  }
+
+  getIssues(page = 1, limit = 10) {
+    const start = (page - 1) * limit;
+    return this.issues.slice(start, start + limit);
+  }
+
+  getIssue(id) {
+    return this.issues.find(i => i.id === parseInt(id, 10));
+  }
+
+  updateIssue(id, data) {
+    const issue = this.getIssue(id);
+    if (!issue) return null;
+    Object.assign(issue, data);
+    return issue;
+  }
+
+  addComment(issueId, comment) {
+    const issue = this.getIssue(issueId);
+    if (!issue) return null;
+    issue.comments.push(comment);
+    return comment;
+  }
+}
+
+module.exports = InMemoryStore;

--- a/src/models/issue.js
+++ b/src/models/issue.js
@@ -1,0 +1,10 @@
+class Issue {
+  constructor({ title, description, status = 'open', assignee = null }) {
+    this.title = title;
+    this.description = description;
+    this.status = status;
+    this.assignee = assignee;
+    this.comments = [];
+  }
+}
+module.exports = Issue;

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,0 +1,7 @@
+class User {
+  constructor({ username, password }) {
+    this.username = username;
+    this.password = password;
+  }
+}
+module.exports = User;

--- a/src/routes/issues.js
+++ b/src/routes/issues.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const router = express.Router();
+const Issue = require('../models/issue');
+
+// list issues with pagination
+router.get('/', (req, res) => {
+  const page = parseInt(req.query.page || '1', 10);
+  const limit = 10;
+  const issues = req.app.locals.store.getIssues(page, limit);
+  res.json({ issues, page });
+});
+
+// create issue
+router.post('/', (req, res) => {
+  const store = req.app.locals.store;
+  const issue = store.addIssue(new Issue(req.body));
+  res.status(201).json(issue);
+});
+
+// view issue details
+router.get('/:id', (req, res) => {
+  const issue = req.app.locals.store.getIssue(req.params.id);
+  if (!issue) return res.status(404).send('Issue not found');
+  res.json(issue);
+});
+
+// update issue (status or assignee)
+router.post('/:id', (req, res) => {
+  const store = req.app.locals.store;
+  const update = {
+    status: req.body.status,
+    assignee: req.body.assignee
+  };
+  const updated = store.updateIssue(req.params.id, update);
+  if (!updated) return res.status(404).send('Issue not found');
+  res.json(updated);
+});
+
+// add comment
+router.post('/:id/comments', (req, res) => {
+  const store = req.app.locals.store;
+  const comment = {
+    author: req.body.author,
+    text: req.body.text,
+    createdAt: new Date()
+  };
+  const result = store.addComment(req.params.id, comment);
+  if (!result) return res.status(404).send('Issue not found');
+  res.status(201).json(result);
+});
+
+module.exports = router;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const router = express.Router();
+const User = require('../models/user');
+
+router.post('/register', (req, res) => {
+  const store = req.app.locals.store;
+  const user = store.addUser(req.body.username, req.body.password);
+  res.status(201).json(user);
+});
+
+router.post('/login', (req, res) => {
+  const store = req.app.locals.store;
+  const user = store.findUser(req.body.username);
+  if (!user || user.password !== req.body.password) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  // naive login: set user in locals (no session for simplicity)
+  req.app.locals.currentUser = user;
+  res.json({ message: 'Logged in' });
+});
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+const InMemoryStore = require('./data/inMemoryStore');
+const issueRoutes = require('./routes/issues');
+const userRoutes = require('./routes/users');
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
+
+// serve React build files if present
+app.use(express.static(path.join(__dirname, '..', 'client', 'build')));
+app.use(express.static(path.join(__dirname, '..', 'public')));
+
+app.locals.store = new InMemoryStore();
+
+app.use('/api/users', userRoutes);
+app.use('/api/issues', issueRoutes);
+
+// react client routing support
+app.get('*', (req, res, next) => {
+  const indexPath = path.join(__dirname, '..', 'client', 'build', 'index.html');
+  if (require('fs').existsSync(indexPath)) {
+    res.sendFile(indexPath);
+  } else {
+    next();
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- switch Express routes to JSON responses
- remove EJS templates
- serve React client from new `client` directory
- document how to run backend and frontend separately

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a15c5d3e8832ea55a1af4b4c3bec9