### PR TITLE
Add floating issue button

### DIFF
--- a/frontend-issue-tracker/src/App.tsx
+++ b/frontend-issue-tracker/src/App.tsx
@@ -7,6 +7,7 @@ import { IssueDetailsView } from "./components/IssueDetailsView";
 import type { Issue, ResolutionStatus as StatusEnum } from "./types"; // Renamed to avoid conflict
 import { ResolutionStatus, statusDisplayNames } from "./types"; // Keep for enum values, import statusDisplayNames
 import { PlusIcon } from "./components/icons/PlusIcon";
+import { FloatingAddButton } from "./components/FloatingAddButton";
 
 const ITEMS_PER_PAGE = 10;
 
@@ -518,6 +519,7 @@ const App: React.FC = () => {
           cancelText="취소"
         />
       )}
+      <FloatingAddButton onClick={() => setShowAddIssueModal(true)} />
     </div>
   );
 };

--- a/frontend-issue-tracker/src/components/FloatingAddButton.tsx
+++ b/frontend-issue-tracker/src/components/FloatingAddButton.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { PlusIcon } from "./icons/PlusIcon";
+
+interface FloatingAddButtonProps {
+  onClick: () => void;
+}
+
+export const FloatingAddButton: React.FC<FloatingAddButtonProps> = ({ onClick }) => {
+  return (
+    <button
+      onClick={onClick}
+      className="fixed bottom-6 right-6 z-40 inline-flex items-center justify-center p-4 rounded-full shadow-lg bg-indigo-600 text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+      aria-label="새 이슈 등록"
+    >
+      <PlusIcon className="w-6 h-6" />
+    </button>
+  );
+};


### PR DESCRIPTION
## Summary
- add `FloatingAddButton` component
- show floating button for quick issue creation

## Testing
- `npx tsc -p frontend-issue-tracker/tsconfig.json --noEmit` *(fails: cannot find module 'react')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68589268a7f8832eb1eaf69bd34621f2