### PR TITLE
Add project-specific issues

### DIFF
--- a/frontend-issue-tracker/src/components/IssueForm.tsx
+++ b/frontend-issue-tracker/src/components/IssueForm.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
-import type { Issue, ResolutionStatus as StatusEnum, IssueType as TypeEnum } from '../types';
+import type { Issue, ResolutionStatus as StatusEnum, IssueType as TypeEnum, Project } from '../types';
 import { ResolutionStatus, statusDisplayNames, IssueType, issueTypeDisplayNames } from '../types';
 import { PlusIcon } from './icons/PlusIcon';
 import type { IssueFormData } from '../App';
@@ -12,6 +12,8 @@ interface IssueFormProps {
   isSubmitting?: boolean;
   submitButtonText?: string;
   isEditMode?: boolean;
+  projects: Project[];
+  selectedProjectId: string | null;
 }
 
 export const IssueForm: React.FC<IssueFormProps> = ({
@@ -21,6 +23,8 @@ export const IssueForm: React.FC<IssueFormProps> = ({
   isSubmitting,
   submitButtonText = "제출",
   isEditMode = false,
+  projects,
+  selectedProjectId,
 }) => {
   const [content, setContent] = useState('');
   const [reporter, setReporter] = useState('');
@@ -30,6 +34,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
   const [type, setType] = useState<TypeEnum>(IssueType.TASK); // Default to TASK
   const [affectsVersion, setAffectsVersion] = useState('');
   const [fixVersion, setFixVersion] = useState('');
+  const [projectId, setProjectId] = useState<string>('');
 
   const [contentError, setContentError] = useState('');
   const [reporterError, setReporterError] = useState('');
@@ -46,6 +51,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
       setType(initialData.type || IssueType.TASK);
       setAffectsVersion(initialData.affectsVersion || '');
       setFixVersion(initialData.fixVersion || '');
+      setProjectId(initialData.projectId || selectedProjectId || projects[0]?.id || '');
     } else {
       // Reset form for adding new issue
       setContent('');
@@ -56,6 +62,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
       setType(IssueType.TASK); // Default for new issues
       setAffectsVersion('');
       setFixVersion('');
+      setProjectId(selectedProjectId || projects[0]?.id || '');
     }
      setContentError('');
      setReporterError('');
@@ -93,6 +100,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
         comment: comment.trim() || undefined,
         type: type,
         affectsVersion: affectsVersion.trim() || undefined,
+        projectId,
       };
       if (isEditMode) {
         formData.status = status;
@@ -104,6 +112,23 @@ export const IssueForm: React.FC<IssueFormProps> = ({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="issue-project" className="block text-sm font-medium text-slate-700 mb-1">
+          프로젝트 <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="issue-project"
+          value={projectId}
+          onChange={(e) => setProjectId(e.target.value)}
+          className="mt-1 block w-full shadow-sm sm:text-sm border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 py-2 px-3"
+          disabled={isSubmitting || isEditMode}
+          required
+        >
+          {projects.map(p => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+      </div>
       <div>
         <label htmlFor="issue-type" className="block text-sm font-medium text-slate-700 mb-1">
           업무 유형 <span className="text-red-500">*</span>

--- a/frontend-issue-tracker/src/components/Sidebar.tsx
+++ b/frontend-issue-tracker/src/components/Sidebar.tsx
@@ -13,6 +13,8 @@ interface SidebarProps {
   onSetViewMode: (viewMode: ViewMode) => void;
   onCreateProject: () => void;
   projects: Project[];
+  currentProjectId: string | null;
+  onSelectProject: (id: string) => void;
 }
 
 interface NavItemProps {
@@ -53,7 +55,7 @@ const NavItem: React.FC<NavItemProps> = ({ icon, label, isActive, onClick, href 
 };
 
 
-export const Sidebar: React.FC<SidebarProps> = ({ currentView, onSetViewMode, onCreateProject, projects }) => {
+export const Sidebar: React.FC<SidebarProps> = ({ currentView, onSetViewMode, onCreateProject, projects, currentProjectId, onSelectProject }) => {
   return (
     <aside className="w-64 bg-slate-800 text-white flex flex-col flex-shrink-0 h-full">
       <div className="p-4 border-b border-slate-700">
@@ -61,7 +63,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ currentView, onSetViewMode, on
           <div className="bg-indigo-500 p-2 rounded-md">
             <ProjectIcon className="w-6 h-6 text-white" />
           </div>
-          <h1 className="text-xl font-semibold">{projects[0]?.name || 'No Project'}</h1>
+          <h1 className="text-xl font-semibold">{projects.find(p => p.id === currentProjectId)?.name || 'No Project'}</h1>
         </div>
       </div>
 
@@ -78,7 +80,13 @@ export const Sidebar: React.FC<SidebarProps> = ({ currentView, onSetViewMode, on
               <div className="px-3 py-1 text-sm text-slate-400">No projects</div>
             )}
             {projects.map((p) => (
-              <NavItem key={p.id} icon={<ProjectIcon className="opacity-50" />} label={p.name} />
+              <NavItem
+                key={p.id}
+                icon={<ProjectIcon className="opacity-50" />}
+                label={p.name}
+                isActive={p.id === currentProjectId}
+                onClick={() => onSelectProject(p.id)}
+              />
             ))}
         </div>
 

--- a/frontend-issue-tracker/src/types.ts
+++ b/frontend-issue-tracker/src/types.ts
@@ -26,7 +26,7 @@ export interface Issue {
   type: IssueType; // New
   affectsVersion?: string; // New
   fixVersion?: string; // New
-  // projectId: string; // Future: For project management
+  projectId: string;
 }
 
 export interface Project {

--- a/types.ts
+++ b/types.ts
@@ -11,6 +11,7 @@ export interface Issue {
   content: string;
   reporter: string;
   status: ResolutionStatus;
+  projectId: string;
   createdAt: string; // ISO date string
 }
     


### PR DESCRIPTION
## Summary
- associate issues with projects on the backend
- support project selection in the UI
- fetch issues per selected project

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*
- `node --check ../server.js`

------
https://chatgpt.com/codex/tasks/task_e_6859e58fe3e4832e80265e9123a90a10