### PR TITLE
Implement admin user registration and user selection

### DIFF
--- a/frontend-issue-tracker/src/components/BoardView.tsx
+++ b/frontend-issue-tracker/src/components/BoardView.tsx
@@ -1,15 +1,16 @@
 
 import React from 'react';
-import type { Issue, BoardColumn, ResolutionStatus } from '../types';
+import type { Issue, BoardColumn, ResolutionStatus, User } from '../types';
 import { IssueCard } from './IssueCard';
 
 interface BoardViewProps {
   columns: BoardColumn[];
   onSelectIssue: (issue: Issue) => void;
   onUpdateStatus: (issueId: string, newStatus: ResolutionStatus) => void; // For D&D or quick actions
+  users: User[];
 }
 
-export const BoardView: React.FC<BoardViewProps> = ({ columns, onSelectIssue, onUpdateStatus }) => {
+export const BoardView: React.FC<BoardViewProps> = ({ columns, onSelectIssue, onUpdateStatus, users }) => {
   if (!columns || columns.length === 0) {
     return (
       <div className="flex-1 flex items-center justify-center p-8 text-slate-500">
@@ -62,6 +63,7 @@ export const BoardView: React.FC<BoardViewProps> = ({ columns, onSelectIssue, on
                   issue={issue}
                   onClick={() => onSelectIssue(issue)}
                   onDragStart={(e) => handleDragStart(e, issue.id)}
+                  users={users}
                 />
               ))
             )}

--- a/frontend-issue-tracker/src/components/IssueCard.tsx
+++ b/frontend-issue-tracker/src/components/IssueCard.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import type { Issue } from '../types';
+import type { Issue, User } from '../types';
 import { statusColors, statusDisplayNames, issueTypeColors, issueTypeDisplayNames } from '../types';
 import { UserAvatarPlaceholderIcon } from './icons/UserAvatarPlaceholderIcon';
 
@@ -9,9 +9,10 @@ interface IssueCardProps {
   issue: Issue;
   onClick: () => void;
   onDragStart: (e: React.DragEvent<HTMLDivElement>) => void;
+  users: User[];
 }
 
-export const IssueCard: React.FC<IssueCardProps> = ({ issue, onClick, onDragStart }) => {
+export const IssueCard: React.FC<IssueCardProps> = ({ issue, onClick, onDragStart, users }) => {
   const getPriorityStyles = () => {
     // Placeholder for priority.
     return 'border-l-4 border-transparent';
@@ -51,7 +52,7 @@ export const IssueCard: React.FC<IssueCardProps> = ({ issue, onClick, onDragStar
         </span>
         <div className="flex items-center space-x-1">
           {issue.assignee && (
-            <div title={`Assigned to: ${issue.assignee}`} className="w-5 h-5 rounded-full bg-slate-200 flex items-center justify-center">
+            <div title={`Assigned to: ${users.find(u => u.userid === issue.assignee)?.username || issue.assignee}`} className="w-5 h-5 rounded-full bg-slate-200 flex items-center justify-center">
               <UserAvatarPlaceholderIcon className="w-3 h-3 text-slate-500" />
             </div>
           )}

--- a/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import type { Issue } from '../types';
+import type { Issue, User } from '../types';
 import { ResolutionStatus, statusDisplayNames, statusColors, IssueType, issueTypeDisplayNames, issueTypeColors } from '../types';
 import { PencilIcon } from './icons/PencilIcon';
 import { TrashIcon } from './icons/TrashIcon';
@@ -13,6 +13,7 @@ interface IssueDetailPanelProps {
   onEditIssue: (issue: Issue) => void;
   onDeleteIssue: (issueId: string) => void;
   onUpdateStatus: (issueId: string, newStatus: ResolutionStatus) => void;
+  users: User[];
 }
 
 const DetailItem: React.FC<{ label: string; value?: string | React.ReactNode; className?: string; isPreLine?: boolean }> = 
@@ -31,6 +32,7 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
   onEditIssue,
   onDeleteIssue,
   onUpdateStatus,
+  users,
 }) => {
   const formattedDate = new Date(issue.createdAt).toLocaleString('ko-KR', {
     year: 'numeric',
@@ -93,8 +95,8 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
                 </span>
             }
           />
-          <DetailItem label="Reporter" value={issue.reporter} />
-          <DetailItem label="Assignee" value={issue.assignee} />
+          <DetailItem label="Reporter" value={users.find(u => u.userid === issue.reporter)?.username || issue.reporter} />
+          <DetailItem label="Assignee" value={issue.assignee ? (users.find(u => u.userid === issue.assignee)?.username || issue.assignee) : undefined} />
           <DetailItem label="Affects Version" value={issue.affectsVersion} />
           <DetailItem label="Fix Version" value={issue.fixVersion} />
           <DetailItem label="Created At" value={formattedDate} className="col-span-2"/>

--- a/frontend-issue-tracker/src/components/IssueDetailsView.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailsView.tsx
@@ -1,10 +1,11 @@
 
 import React from 'react';
-import type { Issue } from '../types';
+import type { Issue, User } from '../types';
 import { statusDisplayNames, statusColors } from '../types';
 
 interface IssueDetailsViewProps {
   issue: Issue;
+  users?: User[];
 }
 
 interface DetailItemProps {
@@ -25,7 +26,7 @@ const DetailItem: React.FC<DetailItemProps> = ({ label, value, isCode, isPreLine
   </div>
 );
 
-export const IssueDetailsView: React.FC<IssueDetailsViewProps> = ({ issue }) => {
+export const IssueDetailsView: React.FC<IssueDetailsViewProps> = ({ issue, users }) => {
   const formattedDate = new Date(issue.createdAt).toLocaleString('ko-KR', {
     year: 'numeric',
     month: 'long',
@@ -39,8 +40,8 @@ export const IssueDetailsView: React.FC<IssueDetailsViewProps> = ({ issue }) => 
     <div className="space-y-6">
       <dl className="space-y-4">
         <DetailItem label="이슈 설명" value={issue.content} isPreLine={true} />
-        <DetailItem label="등록자" value={issue.reporter} />
-        <DetailItem label="담당자" value={issue.assignee || undefined} />
+        <DetailItem label="등록자" value={users?.find(u => u.userid === issue.reporter)?.username || issue.reporter} />
+        <DetailItem label="담당자" value={issue.assignee ? (users?.find(u => u.userid === issue.assignee)?.username || issue.assignee) : undefined} />
         <DetailItem label="코멘트" value={issue.comment || undefined} isPreLine={true} />
         <div>
           <dt className="text-sm font-medium text-slate-500">상태</dt>

--- a/frontend-issue-tracker/src/components/IssueList.tsx
+++ b/frontend-issue-tracker/src/components/IssueList.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import type { Issue } from '../types';
+import type { Issue, User } from '../types';
 import { ResolutionStatus, statusColors, statusDisplayNames, issueTypeDisplayNames, issueTypeColors } from '../types';
 import { TrashIcon } from './icons/TrashIcon';
 import { PencilIcon } from './icons/PencilIcon';
@@ -17,6 +17,7 @@ interface IssueListProps {
   totalIssues: number;
   itemsPerPage: number;
   onPageChange: (page: number) => void;
+  users: User[];
 }
 
 export const IssueList: React.FC<IssueListProps> = ({
@@ -29,6 +30,7 @@ export const IssueList: React.FC<IssueListProps> = ({
   totalIssues,
   itemsPerPage,
   onPageChange,
+  users,
 }) => {
   const totalPages = Math.ceil(totalIssues / itemsPerPage);
 
@@ -176,9 +178,9 @@ export const IssueList: React.FC<IssueListProps> = ({
                 </span>
               </td>
               <td className="px-3 py-3 whitespace-nowrap text-sm text-slate-700">
-                {issue.assignee || <span className="text-slate-400 italic">미지정</span>}
+                {issue.assignee ? (users.find(u => u.userid === issue.assignee)?.username || issue.assignee) : <span className="text-slate-400 italic">미지정</span>}
               </td>
-              <td className="px-3 py-3 whitespace-nowrap text-sm text-slate-700">{issue.reporter}</td>
+              <td className="px-3 py-3 whitespace-nowrap text-sm text-slate-700">{users.find(u => u.userid === issue.reporter)?.username || issue.reporter}</td>
               <td className="px-3 py-3 whitespace-nowrap text-sm text-slate-500">{issue.affectsVersion || '-'}</td>
               <td className="px-3 py-3 whitespace-nowrap text-sm text-slate-500">{issue.fixVersion || '-'}</td>
               <td className="px-3 py-3 whitespace-nowrap text-sm font-medium">

--- a/frontend-issue-tracker/src/components/LoginForm.tsx
+++ b/frontend-issue-tracker/src/components/LoginForm.tsx
@@ -1,36 +1,36 @@
 import React, { useState } from 'react';
 
 interface LoginFormProps {
-  onSubmit: (username: string, password: string) => Promise<void>;
+  onSubmit: (userid: string, password: string) => Promise<void>;
   onCancel: () => void;
   isSubmitting?: boolean;
 }
 
 export const LoginForm: React.FC<LoginFormProps> = ({ onSubmit, onCancel, isSubmitting }) => {
-  const [username, setUsername] = useState('');
+  const [userid, setUserid] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!username.trim() || !password) {
+    if (!userid.trim() || !password) {
       setError('아이디와 비밀번호를 입력하세요.');
       return;
     }
-    onSubmit(username.trim(), password);
+    onSubmit(userid.trim(), password);
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div>
-        <label htmlFor="login-username" className="block text-sm font-medium text-slate-700 mb-1">
+        <label htmlFor="login-userid" className="block text-sm font-medium text-slate-700 mb-1">
           아이디 <span className="text-red-500">*</span>
         </label>
         <input
-          id="login-username"
+          id="login-userid"
           type="text"
-          value={username}
-          onChange={(e) => { setUsername(e.target.value); if (error) setError(''); }}
+          value={userid}
+          onChange={(e) => { setUserid(e.target.value); if (error) setError(''); }}
           className={`mt-1 block w-full shadow-sm sm:text-sm rounded-md py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500 ${error ? 'border-red-500' : 'border-slate-300'}`}
           disabled={isSubmitting}
         />

--- a/frontend-issue-tracker/src/components/RegisterForm.tsx
+++ b/frontend-issue-tracker/src/components/RegisterForm.tsx
@@ -1,30 +1,44 @@
 import React, { useState } from 'react';
 
 interface RegisterFormProps {
-  onSubmit: (username: string, password: string) => Promise<void>;
+  onSubmit: (userid: string, username: string, password: string) => Promise<void>;
   onCancel: () => void;
   isSubmitting?: boolean;
 }
 
 export const RegisterForm: React.FC<RegisterFormProps> = ({ onSubmit, onCancel, isSubmitting }) => {
+  const [userid, setUserid] = useState('');
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!username.trim() || !password) {
-      setError('아이디와 비밀번호를 입력하세요.');
+    if (!userid.trim() || !username.trim() || !password) {
+      setError('아이디, 이름, 비밀번호를 입력하세요.');
       return;
     }
-    onSubmit(username.trim(), password);
+    onSubmit(userid.trim(), username.trim(), password);
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div>
-        <label htmlFor="reg-username" className="block text-sm font-medium text-slate-700 mb-1">
+        <label htmlFor="reg-userid" className="block text-sm font-medium text-slate-700 mb-1">
           아이디 <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="reg-userid"
+          type="text"
+          value={userid}
+          onChange={(e) => { setUserid(e.target.value); if (error) setError(''); }}
+          className={`mt-1 block w-full shadow-sm sm:text-sm rounded-md py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500 ${error ? 'border-red-500' : 'border-slate-300'}`}
+          disabled={isSubmitting}
+        />
+      </div>
+      <div>
+        <label htmlFor="reg-username" className="block text-sm font-medium text-slate-700 mb-1">
+          이름 <span className="text-red-500">*</span>
         </label>
         <input
           id="reg-username"

--- a/frontend-issue-tracker/src/components/TopBar.tsx
+++ b/frontend-issue-tracker/src/components/TopBar.tsx
@@ -17,6 +17,7 @@ interface TopBarProps {
   onStatusFilterChange: (status: ResolutionStatus | 'ALL') => void;
   onCreateIssue: () => void;
   currentUser: string | null;
+  isAdmin: boolean;
   onRequestLogin: () => void;
   onRequestLogout: () => void;
   onRequestRegister: () => void;
@@ -32,6 +33,7 @@ export const TopBar: React.FC<TopBarProps> = ({
   onStatusFilterChange,
   onCreateIssue,
   currentUser,
+  isAdmin,
   onRequestLogin,
   onRequestLogout,
   onRequestRegister,
@@ -123,30 +125,32 @@ export const TopBar: React.FC<TopBarProps> = ({
           </button>
 
           {currentUser ? (
-            <button
-              type="button"
-              onClick={onRequestLogout}
-              className="px-3 py-2 text-sm text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-md"
-            >
-              로그아웃({currentUser})
-            </button>
-          ) : (
             <>
+              {isAdmin && (
+                <button
+                  type="button"
+                  onClick={onRequestRegister}
+                  className="px-3 py-2 text-sm text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-md"
+                >
+                  사용자 등록
+                </button>
+              )}
               <button
                 type="button"
-                onClick={onRequestLogin}
+                onClick={onRequestLogout}
                 className="px-3 py-2 text-sm text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-md"
               >
-                로그인
-              </button>
-              <button
-                type="button"
-                onClick={onRequestRegister}
-                className="px-3 py-2 text-sm text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-md"
-              >
-                회원가입
+                로그아웃({currentUser})
               </button>
             </>
+          ) : (
+            <button
+              type="button"
+              onClick={onRequestLogin}
+              className="px-3 py-2 text-sm text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-md"
+            >
+              로그인
+            </button>
           )}
 
           <button

--- a/frontend-issue-tracker/src/types.ts
+++ b/frontend-issue-tracker/src/types.ts
@@ -30,6 +30,11 @@ export interface Issue {
   projectId: string;
 }
 
+export interface User {
+  userid: string;
+  username: string;
+}
+
 export interface Project {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- add userid-based user management on server
- expose `/api/users` endpoint
- track current user ID and list of users client-side
- show admin-only user registration button
- fetch users for reporter and assignee fields
- map user IDs to names in issue views

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` in frontend *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4b15e42c832eaf43e1e132917d8e