### PR TITLE
Fix attachment downloads

### DIFF
--- a/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
@@ -110,7 +110,11 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
               <ul className="list-disc list-inside space-y-1">
                 {issue.attachments.map((a, idx) => (
                   <li key={idx}>
-                    <a href={`/uploads/${a.filename}`} className="text-indigo-600 hover:underline" download>
+                    <a
+                      href={`/uploads/${a.filename}`}
+                      className="text-indigo-600 hover:underline"
+                      download={a.originalName}
+                    >
                       {a.originalName}
                     </a>
                   </li>

--- a/frontend-issue-tracker/src/components/IssueDetailsView.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailsView.tsx
@@ -62,7 +62,11 @@ export const IssueDetailsView: React.FC<IssueDetailsViewProps> = ({ issue, users
               <ul className="list-disc list-inside space-y-1">
                 {issue.attachments.map((a, idx) => (
                   <li key={idx}>
-                    <a href={`/uploads/${a.filename}`} download className="text-indigo-600 hover:underline">
+                    <a
+                      href={`/uploads/${a.filename}`}
+                      download={a.originalName}
+                      className="text-indigo-600 hover:underline"
+                    >
                       {a.originalName}
                     </a>
                   </li>

--- a/server.js
+++ b/server.js
@@ -76,7 +76,7 @@ app.use(
     saveUninitialized: false,
   })
 );
-app.use("/uploads", express.static(UPLOAD_DIR));
+app.use("/uploads", express.static(UPLOAD_DIR, { fallthrough: false }));
 
 app.use("/api", (req, res, next) => {
   const openPaths = ["/login", "/register", "/current-user"];


### PR DESCRIPTION
## Summary
- ensure Express does not fall through when attachments are missing
- keep original file names when downloading attachments

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685b86bcebc8832ebee4e05c9b5243d1