### PR TITLE
Add Markdown capable editor

### DIFF
--- a/frontend-issue-tracker/index.html
+++ b/frontend-issue-tracker/index.html
@@ -9,6 +9,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://uicdn.toast.com/editor/latest/toastui-editor.min.css">
+    <script src="https://uicdn.toast.com/editor/latest/toastui-editor-all.min.js"></script>
     <script>
       tailwind.config = {
         theme: {

--- a/frontend-issue-tracker/src/components/IssueForm.tsx
+++ b/frontend-issue-tracker/src/components/IssueForm.tsx
@@ -13,6 +13,7 @@ import {
   issueTypeDisplayNames,
 } from "../types";
 import { PlusIcon } from "./icons/PlusIcon";
+import { RichTextEditor } from "./RichTextEditor";
 import type { IssueFormData } from "../App";
 
 interface IssueFormProps {
@@ -233,20 +234,12 @@ export const IssueForm: React.FC<IssueFormProps> = ({
         >
           이슈 설명 <span className="text-red-500">*</span>
         </label>
-        <textarea
-          id="issue-content"
+        <RichTextEditor
           value={content}
-          onChange={(e) => {
-            setContent(e.target.value);
-            if (contentError && e.target.value.trim()) setContentError("");
+          onChange={(val) => {
+            setContent(val);
+            if (contentError && val.trim()) setContentError("");
           }}
-          rows={3}
-          className={`mt-1 block w-full shadow-sm sm:text-sm rounded-md focus:ring-indigo-500 focus:border-indigo-500 ${
-            contentError ? "border-red-500" : "border-slate-300"
-          }`}
-          placeholder="이슈에 대해 자세히 설명해주세요..."
-          required
-          disabled={isSubmitting}
         />
         {contentError && (
           <p className="mt-1 text-xs text-red-600">{contentError}</p>

--- a/frontend-issue-tracker/src/components/RichTextEditor.tsx
+++ b/frontend-issue-tracker/src/components/RichTextEditor.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useRef, useState } from "react";
+
+interface RichTextEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export const RichTextEditor: React.FC<RichTextEditorProps> = ({ value, onChange }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const editorRef = useRef<any>(null);
+  const [mode, setMode] = useState<'wysiwyg' | 'markdown'>('wysiwyg');
+
+  useEffect(() => {
+    const EditorConstructor = (window as any).toastui?.Editor;
+    if (containerRef.current && EditorConstructor && !editorRef.current) {
+      editorRef.current = new EditorConstructor({
+        el: containerRef.current,
+        height: '300px',
+        initialEditType: mode,
+        previewStyle: 'vertical',
+      });
+      editorRef.current.on('change', () => {
+        const md = editorRef.current.getMarkdown();
+        onChange(md);
+      });
+      editorRef.current.setMarkdown(value || '');
+    }
+    return () => {
+      if (editorRef.current) {
+        editorRef.current.destroy();
+        editorRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (editorRef.current) {
+      editorRef.current.setMarkdown(value || '');
+    }
+  }, [value]);
+
+  useEffect(() => {
+    if (editorRef.current) {
+      editorRef.current.changeMode(mode, true);
+    }
+  }, [mode]);
+
+  return (
+    <div>
+      <div className="flex justify-end mb-2">
+        <select
+          className="border rounded px-2 py-1 text-sm"
+          value={mode}
+          onChange={(e) => setMode(e.target.value as 'wysiwyg' | 'markdown')}
+        >
+          <option value="wysiwyg">텍스트 모드</option>
+          <option value="markdown">마크다운</option>
+        </select>
+      </div>
+      <div ref={containerRef} />
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- include Toast UI Editor CDN resources
- add RichTextEditor React component for WYSIWYG/Markdown editing
- use the new editor in the issue form

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b9bdfea88832e952498f31f21f0bc