### PR TITLE
Fix toast UI editor input issues and show rendered content

### DIFF
--- a/frontend-issue-tracker/src/components/IssueDetailsView.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailsView.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import type { Issue, User } from '../types';
 import { statusDisplayNames, statusColors } from '../types';
+import { RichTextViewer } from './RichTextViewer';
 
 interface IssueDetailsViewProps {
   issue: Issue;
@@ -58,7 +59,10 @@ export const IssueDetailsView: React.FC<IssueDetailsViewProps> = ({ issue, users
     <div className="space-y-6">
       <h2 className="text-lg font-semibold">{issue.title}</h2>
       <dl className="space-y-4">
-        <DetailItem label="이슈 설명" value={issue.content} isPreLine={true} />
+        <DetailItem
+          label="이슈 설명"
+          value={<RichTextViewer value={issue.content} />}
+        />
         <DetailItem label="등록자" value={users?.find(u => u.userid === issue.reporter)?.username || issue.reporter} />
         <DetailItem label="담당자" value={issue.assignee ? (users?.find(u => u.userid === issue.assignee)?.username || issue.assignee) : undefined} />
         <DetailItem label="코멘트" value={issue.comment || undefined} isPreLine={true} />

--- a/frontend-issue-tracker/src/components/RichTextEditor.tsx
+++ b/frontend-issue-tracker/src/components/RichTextEditor.tsx
@@ -21,12 +21,12 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
         height: "300px",
         initialEditType: mode,
         previewStyle: "vertical",
+        initialValue: value || "",
       });
       editorRef.current.on("change", () => {
         const md = editorRef.current.getMarkdown();
         onChange(md);
       });
-      editorRef.current.setMarkdown(value || "");
     }
     return () => {
       if (editorRef.current) {
@@ -37,7 +37,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
   }, []);
 
   useEffect(() => {
-    if (editorRef.current) {
+    if (editorRef.current && editorRef.current.getMarkdown() !== value) {
       editorRef.current.setMarkdown(value || "");
     }
   }, [value]);

--- a/frontend-issue-tracker/src/components/RichTextViewer.tsx
+++ b/frontend-issue-tracker/src/components/RichTextViewer.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useRef } from "react";
+
+interface RichTextViewerProps {
+  value: string;
+}
+
+export const RichTextViewer: React.FC<RichTextViewerProps> = ({ value }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const viewerRef = useRef<any>(null);
+
+  useEffect(() => {
+    const EditorConstructor = (window as any).toastui?.Editor;
+    if (containerRef.current && EditorConstructor && !viewerRef.current) {
+      viewerRef.current = EditorConstructor.factory({
+        el: containerRef.current,
+        viewer: true,
+        initialValue: value || "",
+      });
+    }
+    return () => {
+      if (viewerRef.current) {
+        viewerRef.current.destroy();
+        viewerRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (viewerRef.current) {
+      viewerRef.current.setMarkdown(value || "");
+    }
+  }, [value]);
+
+  return <div ref={containerRef} />;
+};


### PR DESCRIPTION
## Summary
- fix RichTextEditor so typing works correctly in WYSIWYG mode
- add RichTextViewer component using toast UI viewer
- display rendered issue content in IssueDetailsView

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ccee0bfe0832eaf2efd4f7097e989