### PR TITLE
Improve issue history details

### DIFF
--- a/frontend-issue-tracker/src/components/IssueHistoryModal.tsx
+++ b/frontend-issue-tracker/src/components/IssueHistoryModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IssueHistoryEntry, User } from '../types';
+import { IssueHistoryEntry, User, statusDisplayNames } from '../types';
 import { Modal } from './Modal';
 
 interface Props {
@@ -20,10 +20,12 @@ export const IssueHistoryModal: React.FC<Props> = ({ isOpen, onClose, history, u
       minute: '2-digit',
     });
     let actionText = entry.action;
-    if (entry.action === 'updated' && entry.changes && entry.changes.length > 0) {
+    if (entry.action === 'updated' && entry.fromStatus && entry.toStatus) {
+      actionText = `상태 변경: ${statusDisplayNames[entry.fromStatus]} → ${statusDisplayNames[entry.toStatus]}`;
+    } else if (entry.action === 'updated' && entry.changes && entry.changes.length > 0) {
       actionText = `updated ${entry.changes.join(', ')}`;
     } else if (entry.action === 'commented') {
-      actionText = 'added a comment';
+      actionText = `commented: ${entry.comment}`;
     }
     return (
       <li key={idx} className="text-sm">

--- a/frontend-issue-tracker/src/types.ts
+++ b/frontend-issue-tracker/src/types.ts
@@ -53,6 +53,8 @@ export interface IssueHistoryEntry {
   timestamp: string;
   changes?: string[];
   comment?: string;
+  fromStatus?: ResolutionStatus;
+  toStatus?: ResolutionStatus;
 }
 
 export interface User {


### PR DESCRIPTION
## Summary
- record from/to status when updating issues
- expose status change info in the frontend issue history modal
- include comment text in history display

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685de789d5e8832e8a5078b9acee62b2