### PR TITLE
Update history modal layout

### DIFF
--- a/frontend-issue-tracker/src/components/IssueHistoryModal.tsx
+++ b/frontend-issue-tracker/src/components/IssueHistoryModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { IssueHistoryEntry, User, statusDisplayNames } from '../types';
 import { Modal } from './Modal';
+import { UserAvatarPlaceholderIcon } from "./icons/UserAvatarPlaceholderIcon";
 
 interface Props {
   isOpen: boolean;
@@ -11,27 +12,53 @@ interface Props {
 
 export const IssueHistoryModal: React.FC<Props> = ({ isOpen, onClose, history, users }) => {
   const renderEntry = (entry: IssueHistoryEntry, idx: number) => {
-    const user = users.find(u => u.userid === entry.userId);
-    const formatted = new Date(entry.timestamp).toLocaleString('ko-KR', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
+    const user = users.find((u) => u.userid === entry.userId);
+    const formatted = new Date(entry.timestamp).toLocaleString("ko-KR", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
     });
-    let actionText = entry.action;
-    if (entry.action === 'updated' && entry.fromStatus && entry.toStatus) {
-      actionText = `상태 변경: ${statusDisplayNames[entry.fromStatus]} → ${statusDisplayNames[entry.toStatus]}`;
-    } else if (entry.action === 'updated' && entry.changes && entry.changes.length > 0) {
-      actionText = `updated ${entry.changes.join(', ')}`;
-    } else if (entry.action === 'commented') {
-      actionText = `commented: ${entry.comment}`;
+
+    let actionLabel = "";
+    let detailText = "";
+    if (entry.action === "created") {
+      actionLabel = "이슈 생성";
+    } else if (entry.action === "updated" && entry.fromStatus && entry.toStatus) {
+      actionLabel = "상태 변경됨";
+      detailText = `${statusDisplayNames[entry.fromStatus]} → ${statusDisplayNames[entry.toStatus]}`;
+    } else if (entry.action === "updated") {
+      actionLabel = "업데이트됨";
+      if (entry.changes && entry.changes.length > 0) {
+        detailText = entry.changes.join(", ");
+      }
+    } else if (entry.action === "commented") {
+      actionLabel = "댓글 작성";
+      detailText = entry.comment || "";
+    } else {
+      actionLabel = entry.action;
     }
+
     return (
-      <li key={idx} className="text-sm">
-        <span className="font-medium">{user ? user.username : entry.userId}</span>{' '}
-        <span className="text-slate-500">{formatted}</span>{' '}
-        <span className="ml-1 whitespace-pre-line">{actionText}</span>
+      <li key={idx} className="flex space-x-2">
+        <div className="w-6 h-6 rounded-full bg-slate-200 flex items-center justify-center flex-shrink-0">
+          <UserAvatarPlaceholderIcon className="w-4 h-4 text-slate-500" />
+        </div>
+        <div className="min-w-0">
+          <div className="flex items-center space-x-1">
+            <span className="text-sm font-medium text-slate-700">
+              {user ? user.username : entry.userId}
+            </span>
+            <span className="text-xs text-slate-600">[{actionLabel}]</span>
+          </div>
+          <div className="text-xs text-slate-400">{formatted}</div>
+          {detailText && (
+            <div className="mt-1 text-sm text-slate-800 whitespace-pre-line">
+              {detailText}
+            </div>
+          )}
+        </div>
       </li>
     );
   };


### PR DESCRIPTION
## Summary
- improve the issue history UI so entries mimic JIRA style

## Testing
- `npx tsc -p frontend-issue-tracker/tsconfig.json --noEmit` *(fails: cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685dece6bb28832e931a9dde2374e92e