### PR TITLE
Add project settings page skeleton

### DIFF
--- a/frontend-issue-tracker/src/App.tsx
+++ b/frontend-issue-tracker/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { IssueForm } from "./components/IssueForm";
 import { IssueList } from "./components/IssueList";
 import { ConfirmationModal } from "./components/ConfirmationModal";
@@ -47,6 +48,7 @@ export type IssueFormData = {
 export type ViewMode = "board" | "list";
 
 const App: React.FC = () => {
+  const navigate = useNavigate();
   const [isAuthenticated, setIsAuthenticated] = useState(false); // Added
   const [issues, setIssues] = useState<Issue[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -268,6 +270,14 @@ const App: React.FC = () => {
   const handleSelectProject = (id: string) => {
     setIssues([]);
     setCurrentProjectId(id);
+  };
+
+  const handleOpenProjectSettings = () => {
+    if (!currentProjectId) return;
+    const project = projects.find((p) => p.id === currentProjectId);
+    navigate(`/projects/${currentProjectId}/settings`, {
+      state: { projectName: project?.name },
+    });
   };
 
   useEffect(() => {
@@ -605,6 +615,8 @@ const App: React.FC = () => {
         projects={projects}
         currentProjectId={currentProjectId}
         onSelectProject={handleSelectProject}
+        isAdmin={isAdmin}
+        onOpenProjectSettings={handleOpenProjectSettings}
       />
       <div className="flex-1 flex flex-col overflow-hidden">
         <TopBar

--- a/frontend-issue-tracker/src/ProjectSettingsPage.tsx
+++ b/frontend-issue-tracker/src/ProjectSettingsPage.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import ProjectSettingsSidebar from './components/ProjectSettingsSidebar';
+
+interface LocationState {
+  projectName?: string;
+}
+
+export const ProjectSettingsPage: React.FC = () => {
+  const { projectId } = useParams<{ projectId: string }>();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { projectName } = (location.state as LocationState) || {};
+  const [activeSection, setActiveSection] = useState('세부사항');
+
+  return (
+    <div className="flex h-screen bg-white text-slate-800">
+      <ProjectSettingsSidebar
+        projectName={projectName || projectId || ''}
+        activeSection={activeSection}
+        onSelectSection={setActiveSection}
+        onBack={() => navigate('/')}
+      />
+      <main className="flex-1 p-6 overflow-auto">
+        <h2 className="text-xl font-semibold mb-4">{activeSection}</h2>
+        <div className="text-slate-500">빈 페이지</div>
+      </main>
+    </div>
+  );
+};
+
+export default ProjectSettingsPage;

--- a/frontend-issue-tracker/src/components/ProjectSettingsSidebar.tsx
+++ b/frontend-issue-tracker/src/components/ProjectSettingsSidebar.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { ArrowLeftIcon } from './icons/ArrowLeftIcon';
+
+interface Props {
+  projectName: string;
+  activeSection: string;
+  onSelectSection: (section: string) => void;
+  onBack: () => void;
+}
+
+const menuItems = ['세부사항', '알림', '버전', '컴포넌트'];
+
+export const ProjectSettingsSidebar: React.FC<Props> = ({
+  projectName,
+  activeSection,
+  onSelectSection,
+  onBack,
+}) => (
+  <aside className="w-64 bg-slate-800 text-white flex flex-col h-full">
+    <div className="p-4 border-b border-slate-700">
+      <div className="flex items-center space-x-2 mb-2">
+        <button
+          onClick={onBack}
+          className="text-slate-300 hover:text-white focus:outline-none"
+        >
+          <ArrowLeftIcon className="w-5 h-5" />
+        </button>
+        <span className="font-bold">프로젝트 설정</span>
+      </div>
+      <div className="text-sm text-slate-300">{projectName}</div>
+    </div>
+    <nav className="flex-1 p-3 space-y-1 overflow-y-auto">
+      {menuItems.map((item) => (
+        <button
+          key={item}
+          onClick={() => onSelectSection(item)}
+          className={`w-full text-left px-3 py-2 rounded-md text-sm ${
+            activeSection === item
+              ? 'bg-slate-700 text-white'
+              : 'text-slate-300 hover:bg-slate-700 hover:text-white'
+          }`}
+        >
+          {item}
+        </button>
+      ))}
+    </nav>
+  </aside>
+);
+
+export default ProjectSettingsSidebar;

--- a/frontend-issue-tracker/src/components/Sidebar.tsx
+++ b/frontend-issue-tracker/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import { BoardIcon } from "./icons/BoardIcon";
 import { ListIcon } from "./icons/ListIcon";
 import { FilterIcon } from "./icons/FilterIcon";
 import { PlusCircleIcon } from "./icons/PlusCircleIcon";
+import { SettingsIcon } from "./icons/SettingsIcon";
 
 interface SidebarProps {
   currentView: ViewMode;
@@ -14,6 +15,8 @@ interface SidebarProps {
   projects: Project[];
   currentProjectId: string | null;
   onSelectProject: (id: string) => void;
+  isAdmin: boolean;
+  onOpenProjectSettings: () => void;
 }
 
 interface NavItemProps {
@@ -78,18 +81,31 @@ export const Sidebar: React.FC<SidebarProps> = ({
   projects,
   currentProjectId,
   onSelectProject,
+  isAdmin,
+  onOpenProjectSettings,
 }) => {
   return (
     <aside className="w-64 bg-slate-800 text-white flex flex-col flex-shrink-0 h-full">
       <div className="p-4 border-b border-slate-700">
-        <div className="flex items-center space-x-3">
-          <div className="bg-indigo-500 p-2 rounded-md">
-            <ProjectIcon className="w-6 h-6 text-white" />
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-3">
+            <div className="bg-indigo-500 p-2 rounded-md">
+              <ProjectIcon className="w-6 h-6 text-white" />
+            </div>
+            <h1 className="text-xl font-semibold">
+              {projects.find((p) => p.id === currentProjectId)?.name ||
+                "No Project"}
+            </h1>
           </div>
-          <h1 className="text-xl font-semibold">
-            {projects.find((p) => p.id === currentProjectId)?.name ||
-              "No Project"}
-          </h1>
+          {isAdmin && currentProjectId && (
+            <button
+              onClick={onOpenProjectSettings}
+              className="text-slate-300 hover:text-white"
+              title="프로젝트 설정"
+            >
+              <SettingsIcon className="w-5 h-5" />
+            </button>
+          )}
         </div>
       </div>
 

--- a/frontend-issue-tracker/src/components/icons/ArrowLeftIcon.tsx
+++ b/frontend-issue-tracker/src/components/icons/ArrowLeftIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface IconProps {
+  className?: string;
+}
+
+export const ArrowLeftIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={className || 'w-6 h-6'}
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+  </svg>
+);

--- a/frontend-issue-tracker/src/components/icons/SettingsIcon.tsx
+++ b/frontend-issue-tracker/src/components/icons/SettingsIcon.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface IconProps {
+  className?: string;
+}
+
+export const SettingsIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={className || 'w-6 h-6'}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.542-.912 3.513.558 2.601 2.1a1.724 1.724 0 001.066 2.574c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.912 1.542-.559 3.513-2.1 2.601a1.724 1.724 0 00-2.574 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.542.912-3.513-.558-2.601-2.1a1.724 1.724 0 00-1.066-2.574c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.912-1.542.558-3.513 2.1-2.601.966.571 2.197.092 2.574-1.066z"
+    />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+    />
+  </svg>
+);

--- a/frontend-issue-tracker/src/index.tsx
+++ b/frontend-issue-tracker/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import IssueDetailPage from './IssueDetailPage';
+import ProjectSettingsPage from './ProjectSettingsPage';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 const rootElement = document.getElementById('root');
@@ -17,6 +18,7 @@ root.render(
       <Routes>
         <Route path="/" element={<App />} />
         <Route path="/issues/:issueKey" element={<IssueDetailPage />} />
+        <Route path="/projects/:projectId/settings" element={<ProjectSettingsPage />} />
       </Routes>
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- add gear icon next to project name for admins
- implement project settings sidebar and page placeholders
- route `/projects/:projectId/settings` to new page
- add navigation from sidebar

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df022b814832ea40de3c98999d80a