### PR TITLE
Add priority field for issues

### DIFF
--- a/frontend-issue-tracker/src/App.tsx
+++ b/frontend-issue-tracker/src/App.tsx
@@ -16,12 +16,14 @@ import type {
   Issue,
   ResolutionStatus as StatusEnum,
   IssueType as TypeEnum,
+  IssuePriority as PriorityEnum,
   Project,
   User,
 } from "./types";
 import {
   ResolutionStatus,
   IssueType,
+  IssuePriority,
   statusDisplayNames,
   boardStatuses,
   boardStatusToTitleMap,
@@ -39,6 +41,7 @@ export type IssueFormData = {
   comment?: string;
   status?: StatusEnum; // Only for edit
   type: TypeEnum; // New, mandatory
+  priority: PriorityEnum;
   affectsVersion?: string; // New
   fixVersion?: string; // New, only for edit
   projectId: string;

--- a/frontend-issue-tracker/src/components/IssueCard.tsx
+++ b/frontend-issue-tracker/src/components/IssueCard.tsx
@@ -6,6 +6,7 @@ import {
   statusDisplayNames,
   issueTypeColors,
   issueTypeDisplayNames,
+  issuePriorityColors,
 } from "../types";
 import { UserAvatarPlaceholderIcon } from "./icons/UserAvatarPlaceholderIcon";
 
@@ -23,8 +24,7 @@ export const IssueCard: React.FC<IssueCardProps> = ({
   users,
 }) => {
   const getPriorityStyles = () => {
-    // Placeholder for priority.
-    return "border-l-4 border-transparent";
+    return `border-l-4 ${issuePriorityColors[issue.priority]}`;
   };
 
   return (

--- a/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
@@ -8,6 +8,7 @@ import {
   IssueType,
   issueTypeDisplayNames,
   issueTypeColors,
+  issuePriorityDisplayNames,
 } from "../types";
 import { PencilIcon } from "./icons/PencilIcon";
 import { TrashIcon } from "./icons/TrashIcon";
@@ -170,6 +171,10 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
                 {issueTypeDisplayNames[issue.type]}
               </span>
             }
+          />
+          <DetailItem
+            label="우선순위"
+            value={issuePriorityDisplayNames[issue.priority]}
           />
           <DetailItem
             label="등록자"

--- a/frontend-issue-tracker/src/components/IssueForm.tsx
+++ b/frontend-issue-tracker/src/components/IssueForm.tsx
@@ -3,6 +3,7 @@ import type {
   Issue,
   ResolutionStatus as StatusEnum,
   IssueType as TypeEnum,
+  IssuePriority as PriorityEnum,
   Project,
   User,
   Version,
@@ -12,6 +13,8 @@ import {
   statusDisplayNames,
   IssueType,
   issueTypeDisplayNames,
+  IssuePriority,
+  issuePriorityDisplayNames,
 } from "../types";
 import { PlusIcon } from "./icons/PlusIcon";
 import { RichTextEditor } from "./RichTextEditor";
@@ -52,6 +55,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
   const [comment, setComment] = useState("");
   const [status, setStatus] = useState<StatusEnum>(ResolutionStatus.OPEN);
   const [type, setType] = useState<TypeEnum>(IssueType.TASK); // Default to TASK
+  const [priority, setPriority] = useState<PriorityEnum>(PriorityEnum.MEDIUM);
   const [affectsVersion, setAffectsVersion] = useState("");
   const [fixVersion, setFixVersion] = useState("");
   const [projectId, setProjectId] = useState<string>("");
@@ -74,6 +78,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
       setComment(initialData.comment || "");
       setStatus(initialData.status || ResolutionStatus.OPEN);
       setType(initialData.type || IssueType.TASK);
+      setPriority(initialData.priority || PriorityEnum.MEDIUM);
       setAffectsVersion(initialData.affectsVersion || "");
       setFixVersion(initialData.fixVersion || "");
       setProjectId(
@@ -89,6 +94,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
       setComment("");
       setStatus(ResolutionStatus.OPEN);
       setType(IssueType.TASK); // Default for new issues
+      setPriority(PriorityEnum.MEDIUM);
       setAffectsVersion("");
       setFixVersion("");
       setProjectId(selectedProjectId || projects[0]?.id || "");
@@ -147,6 +153,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
         assignee: assignee.trim() || undefined,
         comment: comment.trim() || undefined,
         type: type,
+        priority: priority,
         affectsVersion: affectsVersion.trim() || undefined,
         projectId,
         attachments,
@@ -238,6 +245,31 @@ export const IssueForm: React.FC<IssueFormProps> = ({
           )}
         </select>
         {typeError && <p className="mt-1 text-xs text-red-600">{typeError}</p>}
+      </div>
+
+      <div>
+        <label
+          htmlFor="issue-priority"
+          className="block text-sm font-medium text-slate-700 mb-1"
+        >
+          우선순위 <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="issue-priority"
+          value={priority}
+          onChange={(e) => setPriority(e.target.value as PriorityEnum)}
+          className="mt-1 block w-full shadow-sm sm:text-sm border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 py-2 px-3"
+          disabled={isSubmitting}
+          required
+        >
+          {(Object.keys(IssuePriority) as Array<keyof typeof IssuePriority>).map(
+            (pKey) => (
+              <option key={pKey} value={IssuePriority[pKey]}>
+                {issuePriorityDisplayNames[IssuePriority[pKey]]}
+              </option>
+            )
+          )}
+        </select>
       </div>
 
       <div>

--- a/frontend-issue-tracker/src/types.ts
+++ b/frontend-issue-tracker/src/types.ts
@@ -15,6 +15,14 @@ export enum IssueType {
   IMPROVEMENT = "IMPROVEMENT",
 }
 
+export enum IssuePriority {
+  HIGHEST = "HIGHEST",
+  HIGH = "HIGH",
+  MEDIUM = "MEDIUM",
+  LOW = "LOW",
+  LOWEST = "LOWEST",
+}
+
 export interface Issue {
   id: string;
   issueKey: string;
@@ -29,6 +37,7 @@ export interface Issue {
   updatedAt: string; // ISO date string
   resolvedAt?: string; // ISO date string when issue is resolved/closed
   type: IssueType; // New
+  priority: IssuePriority;
   affectsVersion?: string; // New
   fixVersion?: string; // New
   projectId: string;
@@ -99,6 +108,22 @@ export const issueTypeColors: Record<IssueType, string> = {
   [IssueType.BUG]: 'bg-red-100 text-red-800 ring-red-600/20',
   [IssueType.NEW_FEATURE]: 'bg-lime-100 text-lime-800 ring-lime-600/20',
   [IssueType.IMPROVEMENT]: 'bg-amber-100 text-amber-800 ring-amber-600/20',
+};
+
+export const issuePriorityDisplayNames: Record<IssuePriority, string> = {
+  [IssuePriority.HIGHEST]: 'Highest',
+  [IssuePriority.HIGH]: 'High',
+  [IssuePriority.MEDIUM]: 'Medium',
+  [IssuePriority.LOW]: 'Low',
+  [IssuePriority.LOWEST]: 'Lowest',
+};
+
+export const issuePriorityColors: Record<IssuePriority, string> = {
+  [IssuePriority.HIGHEST]: 'border-red-500',
+  [IssuePriority.HIGH]: 'border-orange-500',
+  [IssuePriority.MEDIUM]: 'border-yellow-500',
+  [IssuePriority.LOW]: 'border-green-500',
+  [IssuePriority.LOWEST]: 'border-blue-500',
 };
 
 

--- a/types.ts
+++ b/types.ts
@@ -12,6 +12,7 @@ export interface Issue {
   content: string;
   reporter: string;
   status: ResolutionStatus;
+  priority?: string;
   projectId: string;
   createdAt: string; // ISO date string
   updatedAt: string; // ISO date string


### PR DESCRIPTION
## Summary
- add `IssuePriority` enum with display helpers
- support priority in IssueForm and server API
- display priority in IssueCard and IssueDetailPanel

## Testing
- `npm run lint --prefix frontend-issue-tracker` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6861ce21812c832ebbf9d5afa8d73b11