### PR TITLE
Enable project-specific status and priority

### DIFF
--- a/frontend-issue-tracker/src/App.tsx
+++ b/frontend-issue-tracker/src/App.tsx
@@ -21,12 +21,11 @@ import type {
   User,
 } from "./types";
 import {
-  ResolutionStatus,
   IssueType,
-  IssuePriority,
-  statusDisplayNames,
-  boardStatuses,
   boardStatusToTitleMap,
+  DEFAULT_BOARD_STATUSES,
+  DEFAULT_STATUSES,
+  DEFAULT_PRIORITIES,
 } from "./types";
 import { LoginScreen } from "./components/LoginScreen";
 // import { PlusIcon } from './components/icons/PlusIcon'; // Not used directly here
@@ -70,6 +69,11 @@ const App: React.FC = () => {
   const [users, setUsers] = useState<User[]>([]);
   const [selectedIssueForDetail, setSelectedIssueForDetail] =
     useState<Issue | null>(null);
+
+  const currentProject = useMemo(
+    () => projects.find((p) => p.id === currentProjectId) || null,
+    [projects, currentProjectId]
+  );
 
   const [showAddIssueModal, setShowAddIssueModal] = useState(false);
   const [showEditIssueModal, setShowEditIssueModal] = useState(false);
@@ -584,12 +588,13 @@ const App: React.FC = () => {
   );
 
   const boardColumns = useMemo(() => {
-    return boardStatuses.map((status) => ({
+    const statuses = currentProject?.statuses || DEFAULT_BOARD_STATUSES;
+    return statuses.map((status) => ({
       id: status,
-      title: boardStatusToTitleMap[status],
+      title: boardStatusToTitleMap[status] || status,
       issues: baseFilteredIssues.filter((issue) => issue.status === status),
     }));
-  }, [baseFilteredIssues]);
+  }, [baseFilteredIssues, currentProject]);
 
   if (isLoading && issues.length === 0) {
     return (
@@ -628,6 +633,7 @@ const App: React.FC = () => {
           onSearchTermChange={setSearchTerm}
           statusFilter={statusFilter}
           onStatusFilterChange={setStatusFilter}
+          statuses={currentProject?.statuses || DEFAULT_STATUSES}
           onCreateIssue={() => {
             setShowAddIssueModal(true);
             setError(null);
@@ -709,6 +715,7 @@ const App: React.FC = () => {
                     itemsPerPage={ITEMS_PER_PAGE_LIST}
                     onPageChange={handlePageChange}
                     users={users}
+                    statuses={currentProject?.statuses || DEFAULT_STATUSES}
                   />
                 </div>
               )}
@@ -726,6 +733,10 @@ const App: React.FC = () => {
           onUpdateStatus={updateIssueStatus}
           users={users}
           onIssueUpdated={handleIssueUpdated}
+          statuses={
+            projects.find((p) => p.id === selectedIssueForDetail.projectId)?.statuses ||
+            DEFAULT_STATUSES
+          }
         />
       )}
 
@@ -750,6 +761,8 @@ const App: React.FC = () => {
           users={users}
           currentUserId={currentUserId}
           currentUserName={currentUser}
+          statuses={currentProject?.statuses || DEFAULT_STATUSES}
+          priorities={currentProject?.priorities || DEFAULT_PRIORITIES}
         />
       </Modal>
 
@@ -791,6 +804,14 @@ const App: React.FC = () => {
             users={users}
             currentUserId={currentUserId}
             currentUserName={currentUser}
+            statuses={
+              projects.find((p) => p.id === selectedIssueForEdit.projectId)?.statuses ||
+              DEFAULT_STATUSES
+            }
+            priorities={
+              projects.find((p) => p.id === selectedIssueForEdit.projectId)?.priorities ||
+              DEFAULT_PRIORITIES
+            }
           />
         </Modal>
       )}

--- a/frontend-issue-tracker/src/ProjectSettingsPage.tsx
+++ b/frontend-issue-tracker/src/ProjectSettingsPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import ProjectSettingsSidebar from './components/ProjectSettingsSidebar';
 import ProjectVersions from './components/ProjectVersions';
+import ProjectIssueSettings from './components/ProjectIssueSettings';
 import type { User } from './types';
 
 interface LocationState {
@@ -49,6 +50,12 @@ export const ProjectSettingsPage: React.FC = () => {
         {activeSection === '버전' ? (
           projectId ? (
             <ProjectVersions projectId={projectId} users={users} currentUserId={currentUserId} />
+          ) : (
+            <div>프로젝트 ID가 없습니다.</div>
+          )
+        ) : activeSection === '이슈 설정' ? (
+          projectId ? (
+            <ProjectIssueSettings projectId={projectId} />
           ) : (
             <div>프로젝트 ID가 없습니다.</div>
           )

--- a/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
@@ -1,14 +1,16 @@
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import type { Issue, User } from "../types";
-import {
+import type {
   ResolutionStatus,
+} from "../types";
+import {
   statusDisplayNames,
   statusColors,
   IssueType,
   issueTypeDisplayNames,
   issueTypeColors,
-  issuePriorityDisplayNames,
+  getPriorityDisplayName,
 } from "../types";
 import { PencilIcon } from "./icons/PencilIcon";
 import { TrashIcon } from "./icons/TrashIcon";
@@ -26,6 +28,7 @@ interface IssueDetailPanelProps {
   onUpdateStatus: (issueId: string, newStatus: ResolutionStatus) => void;
   users: User[];
   onIssueUpdated: (issue: Issue) => void;
+  statuses: ResolutionStatus[];
 }
 
 const DetailItem: React.FC<{
@@ -56,6 +59,7 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
   onUpdateStatus,
   users,
   onIssueUpdated,
+  statuses,
 }) => {
   const [newComment, setNewComment] = useState("");
   const [localIssue, setLocalIssue] = useState(issue);
@@ -142,21 +146,11 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
                 } appearance-none text-center font-medium`}
                 aria-label="Update issue status"
               >
-                {(
-                  Object.keys(ResolutionStatus) as Array<
-                    keyof typeof ResolutionStatus
-                  >
-                ).map((statusKey) =>
-                  ResolutionStatus[statusKey] ? (
-                    <option
-                      key={statusKey}
-                      value={ResolutionStatus[statusKey]}
-                      className="bg-white text-slate-800"
-                    >
-                      {statusDisplayNames[ResolutionStatus[statusKey]]}
-                    </option>
-                  ) : null
-                )}
+                {statuses.map((s) => (
+                  <option key={s} value={s} className="bg-white text-slate-800">
+                    {statusDisplayNames[s] || s}
+                  </option>
+                ))}
               </select>
             }
           />
@@ -174,7 +168,7 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
           />
           <DetailItem
             label="우선순위"
-            value={issuePriorityDisplayNames[issue.priority]}
+            value={getPriorityDisplayName(issue.priority)}
           />
           <DetailItem
             label="등록자"

--- a/frontend-issue-tracker/src/components/IssueForm.tsx
+++ b/frontend-issue-tracker/src/components/IssueForm.tsx
@@ -9,12 +9,10 @@ import type {
   Version,
 } from "../types";
 import {
-  ResolutionStatus,
   statusDisplayNames,
   IssueType,
   issueTypeDisplayNames,
-  IssuePriority,
-  issuePriorityDisplayNames,
+  getPriorityDisplayName,
 } from "../types";
 import { PlusIcon } from "./icons/PlusIcon";
 import { RichTextEditor } from "./RichTextEditor";
@@ -32,6 +30,8 @@ interface IssueFormProps {
   users: User[];
   currentUserId: string | null;
   currentUserName: string | null;
+  statuses: StatusEnum[];
+  priorities: PriorityEnum[];
 }
 
 export const IssueForm: React.FC<IssueFormProps> = ({
@@ -53,9 +53,9 @@ export const IssueForm: React.FC<IssueFormProps> = ({
   const [reporterName, setReporterName] = useState("");
   const [assignee, setAssignee] = useState("");
   const [comment, setComment] = useState("");
-  const [status, setStatus] = useState<StatusEnum>(ResolutionStatus.OPEN);
+  const [status, setStatus] = useState<StatusEnum>(statuses[0]);
   const [type, setType] = useState<TypeEnum>(IssueType.TASK); // Default to TASK
-  const [priority, setPriority] = useState<PriorityEnum>(IssuePriority.MEDIUM);
+  const [priority, setPriority] = useState<PriorityEnum>(priorities[0]);
   const [affectsVersion, setAffectsVersion] = useState("");
   const [fixVersion, setFixVersion] = useState("");
   const [projectId, setProjectId] = useState<string>("");
@@ -76,9 +76,9 @@ export const IssueForm: React.FC<IssueFormProps> = ({
       setReporterName(reporterUser ? reporterUser.username : "");
       setAssignee(initialData.assignee || "");
       setComment(initialData.comment || "");
-      setStatus(initialData.status || ResolutionStatus.OPEN);
+      setStatus(initialData.status || statuses[0]);
       setType(initialData.type || IssueType.TASK);
-      setPriority(initialData.priority || IssuePriority.MEDIUM);
+      setPriority(initialData.priority || priorities[0]);
       setAffectsVersion(initialData.affectsVersion || "");
       setFixVersion(initialData.fixVersion || "");
       setProjectId(
@@ -92,9 +92,9 @@ export const IssueForm: React.FC<IssueFormProps> = ({
       setReporterName(currentUserName || "");
       setAssignee("");
       setComment("");
-      setStatus(ResolutionStatus.OPEN);
+      setStatus(statuses[0]);
       setType(IssueType.TASK); // Default for new issues
-      setPriority(IssuePriority.MEDIUM);
+      setPriority(priorities[0]);
       setAffectsVersion("");
       setFixVersion("");
       setProjectId(selectedProjectId || projects[0]?.id || "");
@@ -262,11 +262,9 @@ export const IssueForm: React.FC<IssueFormProps> = ({
           disabled={isSubmitting}
           required
         >
-          {(
-            Object.keys(IssuePriority) as Array<keyof typeof IssuePriority>
-          ).map((pKey) => (
-            <option key={pKey} value={IssuePriority[pKey]}>
-              {issuePriorityDisplayNames[IssuePriority[pKey]]}
+          {priorities.map((p) => (
+            <option key={p} value={p}>
+              {getPriorityDisplayName(p)}
             </option>
           ))}
         </select>
@@ -349,13 +347,9 @@ export const IssueForm: React.FC<IssueFormProps> = ({
               className="mt-1 block w-full shadow-sm sm:text-sm border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 py-2 px-3"
               disabled={isSubmitting}
             >
-              {(
-                Object.keys(ResolutionStatus) as Array<
-                  keyof typeof ResolutionStatus
-                >
-              ).map((statusKey) => (
-                <option key={statusKey} value={ResolutionStatus[statusKey]}>
-                  {statusDisplayNames[ResolutionStatus[statusKey]]}
+              {statuses.map((st) => (
+                <option key={st} value={st}>
+                  {statusDisplayNames[st] || st}
                 </option>
               ))}
             </select>

--- a/frontend-issue-tracker/src/components/IssueHistoryModal.tsx
+++ b/frontend-issue-tracker/src/components/IssueHistoryModal.tsx
@@ -27,7 +27,7 @@ export const IssueHistoryModal: React.FC<Props> = ({ isOpen, onClose, history, u
       actionLabel = "이슈 생성";
     } else if (entry.action === "updated" && entry.fromStatus && entry.toStatus) {
       actionLabel = "상태 변경됨";
-      detailText = `${statusDisplayNames[entry.fromStatus]} → ${statusDisplayNames[entry.toStatus]}`;
+      detailText = `${statusDisplayNames[entry.fromStatus] || entry.fromStatus} → ${statusDisplayNames[entry.toStatus] || entry.toStatus}`;
     } else if (entry.action === "updated") {
       actionLabel = "업데이트됨";
       if (entry.changes && entry.changes.length > 0) {

--- a/frontend-issue-tracker/src/components/IssueList.tsx
+++ b/frontend-issue-tracker/src/components/IssueList.tsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import type { Issue, User } from '../types';
-import { ResolutionStatus, statusColors, statusDisplayNames, issueTypeDisplayNames, issueTypeColors } from '../types';
+import type { ResolutionStatus } from '../types';
+import { statusColors, statusDisplayNames, issueTypeDisplayNames, issueTypeColors } from '../types';
 import { TrashIcon } from './icons/TrashIcon';
 import { PencilIcon } from './icons/PencilIcon';
 import { EyeIcon } from './icons/EyeIcon';
@@ -18,6 +19,7 @@ interface IssueListProps {
   itemsPerPage: number;
   onPageChange: (page: number) => void;
   users: User[];
+  statuses: ResolutionStatus[];
 }
 
 export const IssueList: React.FC<IssueListProps> = ({
@@ -31,6 +33,7 @@ export const IssueList: React.FC<IssueListProps> = ({
   itemsPerPage,
   onPageChange,
   users,
+  statuses,
 }) => {
   const totalPages = Math.ceil(totalIssues / itemsPerPage);
 
@@ -187,18 +190,16 @@ export const IssueList: React.FC<IssueListProps> = ({
               <td className="px-3 py-3 whitespace-nowrap text-sm font-medium">
                 <div className="flex items-center space-x-1">
                   <select
-                      value={issue.status}
-                      onChange={(e) => handleStatusChange(issue.id, e)}
-                      className="text-xs rounded-md border-slate-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 py-1 pl-2 pr-7"
-                      aria-label={`${issue.title} 상태 변경`}
-                    >
-                      {(Object.keys(ResolutionStatus) as Array<keyof typeof ResolutionStatus>).map(statusKey => (
-                        ResolutionStatus[statusKey] ?
-                        <option key={statusKey} value={ResolutionStatus[statusKey]}>
-                          {statusDisplayNames[ResolutionStatus[statusKey]]}
-                        </option>
-                        : null
-                      ))}
+                    value={issue.status}
+                    onChange={(e) => handleStatusChange(issue.id, e)}
+                    className="text-xs rounded-md border-slate-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 py-1 pl-2 pr-7"
+                    aria-label={`${issue.title} 상태 변경`}
+                  >
+                    {statuses.map((s) => (
+                      <option key={s} value={s}>
+                        {statusDisplayNames[s] || s}
+                      </option>
+                    ))}
                   </select>
                    <button
                     onClick={() => onViewIssue(issue)}

--- a/frontend-issue-tracker/src/components/ProjectIssueSettings.tsx
+++ b/frontend-issue-tracker/src/components/ProjectIssueSettings.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useState } from 'react';
+import { DEFAULT_STATUSES, DEFAULT_PRIORITIES } from '../types';
+
+interface Props {
+  projectId: string;
+}
+
+const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
+  const [statuses, setStatuses] = useState<string[]>([]);
+  const [priorities, setPriorities] = useState<string[]>([]);
+  const [newStatus, setNewStatus] = useState('');
+  const [newPriority, setNewPriority] = useState('');
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      const res = await fetch(`/api/projects/${projectId}/issue-settings`);
+      if (res.ok) {
+        const data = await res.json();
+        setStatuses(data.statuses || DEFAULT_STATUSES);
+        setPriorities(data.priorities || DEFAULT_PRIORITIES);
+      } else {
+        setStatuses(DEFAULT_STATUSES);
+        setPriorities(DEFAULT_PRIORITIES);
+      }
+    };
+    fetchSettings();
+  }, [projectId]);
+
+  const handleSave = async () => {
+    await fetch(`/api/projects/${projectId}/issue-settings`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ statuses, priorities }),
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="font-semibold mb-2">Issue Statuses</h3>
+        <ul className="space-y-2">
+          {statuses.map((s, idx) => (
+            <li key={idx} className="flex space-x-2">
+              <input
+                value={s}
+                onChange={(e) =>
+                  setStatuses(statuses.map((v, i) => (i === idx ? e.target.value : v)))
+                }
+                className="border border-slate-300 rounded px-2 py-1 flex-1"
+              />
+              <button
+                onClick={() => setStatuses(statuses.filter((_, i) => i !== idx))}
+                className="text-red-600 px-2"
+              >
+                삭제
+              </button>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-2 flex space-x-2">
+          <input
+            value={newStatus}
+            onChange={(e) => setNewStatus(e.target.value)}
+            className="border border-slate-300 rounded px-2 py-1 flex-1"
+            placeholder="새 상태"
+          />
+          <button
+            onClick={() => {
+              if (newStatus.trim()) {
+                setStatuses([...statuses, newStatus.trim()]);
+                setNewStatus('');
+              }
+            }}
+            className="px-3 py-1 bg-slate-200 rounded"
+          >
+            추가
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="font-semibold mb-2">Issue Priorities</h3>
+        <ul className="space-y-2">
+          {priorities.map((p, idx) => (
+            <li key={idx} className="flex space-x-2">
+              <input
+                value={p}
+                onChange={(e) =>
+                  setPriorities(priorities.map((v, i) => (i === idx ? e.target.value : v)))
+                }
+                className="border border-slate-300 rounded px-2 py-1 flex-1"
+              />
+              <button
+                onClick={() => setPriorities(priorities.filter((_, i) => i !== idx))}
+                className="text-red-600 px-2"
+              >
+                삭제
+              </button>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-2 flex space-x-2">
+          <input
+            value={newPriority}
+            onChange={(e) => setNewPriority(e.target.value)}
+            className="border border-slate-300 rounded px-2 py-1 flex-1"
+            placeholder="새 우선순위"
+          />
+          <button
+            onClick={() => {
+              if (newPriority.trim()) {
+                setPriorities([...priorities, newPriority.trim()]);
+                setNewPriority('');
+              }
+            }}
+            className="px-3 py-1 bg-slate-200 rounded"
+          >
+            추가
+          </button>
+        </div>
+      </div>
+
+      <button onClick={handleSave} className="px-4 py-2 bg-indigo-600 text-white rounded">
+        저장
+      </button>
+    </div>
+  );
+};
+
+export default ProjectIssueSettings;

--- a/frontend-issue-tracker/src/components/ProjectSettingsSidebar.tsx
+++ b/frontend-issue-tracker/src/components/ProjectSettingsSidebar.tsx
@@ -8,7 +8,7 @@ interface Props {
   onBack: () => void;
 }
 
-const menuItems = ['세부사항', '알림', '버전', '컴포넌트'];
+const menuItems = ['세부사항', '알림', '버전', '컴포넌트', '이슈 설정'];
 
 export const ProjectSettingsSidebar: React.FC<Props> = ({
   projectName,

--- a/frontend-issue-tracker/src/components/TopBar.tsx
+++ b/frontend-issue-tracker/src/components/TopBar.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { ViewMode } from "../App";
-import { ResolutionStatus, statusDisplayNames } from "../types";
+import type { ResolutionStatus } from "../types";
+import { statusDisplayNames } from "../types";
 import { SearchIcon } from "./icons/SearchIcon";
 import { UserAvatarPlaceholderIcon } from "./icons/UserAvatarPlaceholderIcon";
 import { GlobeIcon } from "./icons/GlobeIcon";
@@ -14,6 +15,7 @@ interface TopBarProps {
   onSearchTermChange: (term: string) => void;
   statusFilter: ResolutionStatus | "ALL";
   onStatusFilterChange: (status: ResolutionStatus | "ALL") => void;
+  statuses: ResolutionStatus[];
   onCreateIssue: () => void;
   currentUser: string | null;
   isAdmin: boolean;
@@ -95,17 +97,11 @@ export const TopBar: React.FC<TopBarProps> = ({
               aria-label="Filter by status"
             >
               <option value="ALL">All Statuses</option>
-              {(
-                Object.keys(ResolutionStatus) as Array<
-                  keyof typeof ResolutionStatus
-                >
-              ).map((key) =>
-                ResolutionStatus[key] ? (
-                  <option key={key} value={ResolutionStatus[key]}>
-                    {statusDisplayNames[ResolutionStatus[key]]}
-                  </option>
-                ) : null
-              )}
+              {statuses.map((s) => (
+                <option key={s} value={s}>
+                  {statusDisplayNames[s] || s}
+                </option>
+              ))}
             </select>
           </div>
 

--- a/frontend-issue-tracker/src/types.ts
+++ b/frontend-issue-tracker/src/types.ts
@@ -1,12 +1,13 @@
 
-export enum ResolutionStatus {
-  OPEN = "OPEN",
-  IN_PROGRESS = "IN_PROGRESS",
-  RESOLVED = "RESOLVED", // Represents "수정 완료"
-  VALIDATING = "VALIDATING", // New "검증" status
-  CLOSED = "CLOSED",
-  WONT_DO = "WONT_DO",
-}
+export type ResolutionStatus = string;
+export const DEFAULT_STATUSES: ResolutionStatus[] = [
+  "OPEN",
+  "IN_PROGRESS",
+  "RESOLVED",
+  "VALIDATING",
+  "CLOSED",
+  "WONT_DO",
+];
 
 export enum IssueType {
   TASK = "TASK",
@@ -15,13 +16,14 @@ export enum IssueType {
   IMPROVEMENT = "IMPROVEMENT",
 }
 
-export enum IssuePriority {
-  HIGHEST = "HIGHEST",
-  HIGH = "HIGH",
-  MEDIUM = "MEDIUM",
-  LOW = "LOW",
-  LOWEST = "LOWEST",
-}
+export type IssuePriority = string;
+export const DEFAULT_PRIORITIES: IssuePriority[] = [
+  "HIGHEST",
+  "HIGH",
+  "MEDIUM",
+  "LOW",
+  "LOWEST",
+];
 
 export interface Issue {
   id: string;
@@ -76,25 +78,28 @@ export interface Project {
   id: string;
   name: string;
   key: string;
+  statuses?: ResolutionStatus[];
+  priorities?: IssuePriority[];
 }
 
-export const statusColors: Record<ResolutionStatus, string> = {
-  [ResolutionStatus.OPEN]: 'bg-blue-100 text-blue-800 ring-blue-600/20',
-  [ResolutionStatus.IN_PROGRESS]: 'bg-yellow-100 text-yellow-800 ring-yellow-600/20',
-  [ResolutionStatus.RESOLVED]: 'bg-teal-100 text-teal-800 ring-teal-600/20',
-  [ResolutionStatus.VALIDATING]: 'bg-purple-100 text-purple-800 ring-purple-600/20',
-  [ResolutionStatus.CLOSED]: 'bg-slate-100 text-slate-800 ring-slate-600/20',
-  [ResolutionStatus.WONT_DO]: 'bg-gray-100 text-gray-800 ring-gray-600/20',
+export const statusColors: Record<string, string> = {
+  OPEN: 'bg-blue-100 text-blue-800 ring-blue-600/20',
+  IN_PROGRESS: 'bg-yellow-100 text-yellow-800 ring-yellow-600/20',
+  RESOLVED: 'bg-teal-100 text-teal-800 ring-teal-600/20',
+  VALIDATING: 'bg-purple-100 text-purple-800 ring-purple-600/20',
+  CLOSED: 'bg-slate-100 text-slate-800 ring-slate-600/20',
+  WONT_DO: 'bg-gray-100 text-gray-800 ring-gray-600/20',
 };
 
-export const statusDisplayNames: Record<ResolutionStatus, string> = {
-  [ResolutionStatus.OPEN]: "열림",
-  [ResolutionStatus.IN_PROGRESS]: "수정 중",
-  [ResolutionStatus.RESOLVED]: "수정 완료",
-  [ResolutionStatus.VALIDATING]: "검증",
-  [ResolutionStatus.CLOSED]: "닫힘",
-  [ResolutionStatus.WONT_DO]: "원치 않음",
+export const statusDisplayNames: Record<string, string> = {
+  OPEN: '열림',
+  IN_PROGRESS: '수정 중',
+  RESOLVED: '수정 완료',
+  VALIDATING: '검증',
+  CLOSED: '닫힘',
+  WONT_DO: '원치 않음',
 };
+export const getStatusDisplayName = (s: string) => statusDisplayNames[s] || s;
 
 export const issueTypeDisplayNames: Record<IssueType, string> = {
   [IssueType.TASK]: "작업",
@@ -110,21 +115,23 @@ export const issueTypeColors: Record<IssueType, string> = {
   [IssueType.IMPROVEMENT]: 'bg-amber-100 text-amber-800 ring-amber-600/20',
 };
 
-export const issuePriorityDisplayNames: Record<IssuePriority, string> = {
-  [IssuePriority.HIGHEST]: 'Highest',
-  [IssuePriority.HIGH]: 'High',
-  [IssuePriority.MEDIUM]: 'Medium',
-  [IssuePriority.LOW]: 'Low',
-  [IssuePriority.LOWEST]: 'Lowest',
+export const issuePriorityDisplayNames: Record<string, string> = {
+  HIGHEST: 'Highest',
+  HIGH: 'High',
+  MEDIUM: 'Medium',
+  LOW: 'Low',
+  LOWEST: 'Lowest',
 };
 
-export const issuePriorityColors: Record<IssuePriority, string> = {
-  [IssuePriority.HIGHEST]: 'border-red-500',
-  [IssuePriority.HIGH]: 'border-orange-500',
-  [IssuePriority.MEDIUM]: 'border-yellow-500',
-  [IssuePriority.LOW]: 'border-green-500',
-  [IssuePriority.LOWEST]: 'border-blue-500',
+export const issuePriorityColors: Record<string, string> = {
+  HIGHEST: 'border-red-500',
+  HIGH: 'border-orange-500',
+  MEDIUM: 'border-yellow-500',
+  LOW: 'border-green-500',
+  LOWEST: 'border-blue-500',
 };
+export const getPriorityDisplayName = (p: string) =>
+  issuePriorityDisplayNames[p] || p;
 
 
 export interface BoardColumn {
@@ -133,20 +140,20 @@ export interface BoardColumn {
   issues: Issue[];
 }
 
-export const boardStatuses: ResolutionStatus[] = [
-  ResolutionStatus.OPEN,
-  ResolutionStatus.IN_PROGRESS,
-  ResolutionStatus.RESOLVED,
-  ResolutionStatus.VALIDATING,
+export const DEFAULT_BOARD_STATUSES: ResolutionStatus[] = [
+  "OPEN",
+  "IN_PROGRESS",
+  "RESOLVED",
+  "VALIDATING",
 ];
 
-export const boardStatusToTitleMap: Record<ResolutionStatus, string> = {
-  [ResolutionStatus.OPEN]: statusDisplayNames[ResolutionStatus.OPEN],
-  [ResolutionStatus.IN_PROGRESS]: statusDisplayNames[ResolutionStatus.IN_PROGRESS],
-  [ResolutionStatus.RESOLVED]: statusDisplayNames[ResolutionStatus.RESOLVED],
-  [ResolutionStatus.VALIDATING]: statusDisplayNames[ResolutionStatus.VALIDATING],
-  [ResolutionStatus.CLOSED]: statusDisplayNames[ResolutionStatus.CLOSED],
-  [ResolutionStatus.WONT_DO]: statusDisplayNames[ResolutionStatus.WONT_DO],
+export const boardStatusToTitleMap: Record<string, string> = {
+  OPEN: statusDisplayNames["OPEN"],
+  IN_PROGRESS: statusDisplayNames["IN_PROGRESS"],
+  RESOLVED: statusDisplayNames["RESOLVED"],
+  VALIDATING: statusDisplayNames["VALIDATING"],
+  CLOSED: statusDisplayNames["CLOSED"],
+  WONT_DO: statusDisplayNames["WONT_DO"],
 };
 
 export interface Version {


### PR DESCRIPTION
## Summary
- allow per-project issue statuses and priorities on the backend
- add API to edit project issue settings
- fetch project settings and use them in the frontend
- add ProjectIssueSettings component and menu
- adapt forms and views to use dynamic statuses/priorities
- fix runtime import errors by using type-only imports and passing statuses to IssueList

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861dc3ed9ec832eb72dec41e0d66c90