### PR TITLE
Support custom status names

### DIFF
--- a/frontend-issue-tracker/src/App.tsx
+++ b/frontend-issue-tracker/src/App.tsx
@@ -22,8 +22,6 @@ import type {
 } from "./types";
 import {
   IssueType,
-  boardStatusToTitleMap,
-  DEFAULT_BOARD_STATUSES,
   DEFAULT_STATUSES,
   DEFAULT_PRIORITIES,
 } from "./types";
@@ -588,11 +586,11 @@ const App: React.FC = () => {
   );
 
   const boardColumns = useMemo(() => {
-    const statuses = currentProject?.statuses || DEFAULT_BOARD_STATUSES;
-    return statuses.map((status) => ({
-      id: status,
-      title: boardStatusToTitleMap[status] || status,
-      issues: baseFilteredIssues.filter((issue) => issue.status === status),
+    const statuses = currentProject?.statuses || DEFAULT_STATUSES;
+    return statuses.map((s) => ({
+      id: s.id,
+      title: s.name,
+      issues: baseFilteredIssues.filter((issue) => issue.status === s.id),
     }));
   }, [baseFilteredIssues, currentProject]);
 

--- a/frontend-issue-tracker/src/components/IssueCard.tsx
+++ b/frontend-issue-tracker/src/components/IssueCard.tsx
@@ -3,7 +3,6 @@ import { Link } from "react-router-dom";
 import type { Issue, User } from "../types";
 import {
   statusColors,
-  statusDisplayNames,
   issueTypeColors,
   issueTypeDisplayNames,
   issuePriorityColors,
@@ -64,9 +63,9 @@ export const IssueCard: React.FC<IssueCardProps> = ({
             statusColors[issue.status]
           } bg-opacity-80`}
           style={{ fontSize: "0.65rem" }}
-          title={`Status: ${statusDisplayNames[issue.status]}`}
+          title={`Status: ${issue.status}`}
         >
-          {statusDisplayNames[issue.status]}
+          {issue.status}
         </span>
         <div className="flex items-center space-x-1">
           {issue.assignee && (

--- a/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
@@ -3,9 +3,9 @@ import { Link } from "react-router-dom";
 import type { Issue, User } from "../types";
 import type {
   ResolutionStatus,
+  StatusOption,
 } from "../types";
 import {
-  statusDisplayNames,
   statusColors,
   IssueType,
   issueTypeDisplayNames,
@@ -28,7 +28,7 @@ interface IssueDetailPanelProps {
   onUpdateStatus: (issueId: string, newStatus: ResolutionStatus) => void;
   users: User[];
   onIssueUpdated: (issue: Issue) => void;
-  statuses: ResolutionStatus[];
+  statuses: StatusOption[];
 }
 
 const DetailItem: React.FC<{
@@ -147,8 +147,12 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
                 aria-label="Update issue status"
               >
                 {statuses.map((s) => (
-                  <option key={s} value={s} className="bg-white text-slate-800">
-                    {statusDisplayNames[s] || s}
+                  <option
+                    key={s.id}
+                    value={s.id}
+                    className="bg-white text-slate-800"
+                  >
+                    {s.name}
                   </option>
                 ))}
               </select>

--- a/frontend-issue-tracker/src/components/IssueDetailsView.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailsView.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import type { Issue, User } from '../types';
-import { statusDisplayNames, statusColors } from '../types';
+import { statusColors } from '../types';
 import { RichTextViewer } from './RichTextViewer';
 
 interface IssueDetailsViewProps {
@@ -108,7 +108,7 @@ export const IssueDetailsView: React.FC<IssueDetailsViewProps> = ({ issue, users
             <span
               className={`px-3 py-1 text-xs font-semibold rounded-full ring-1 ring-inset ${statusColors[issue.status]}`}
             >
-              {statusDisplayNames[issue.status]}
+              {issue.status}
             </span>
           </dd>
         </div>

--- a/frontend-issue-tracker/src/components/IssueForm.tsx
+++ b/frontend-issue-tracker/src/components/IssueForm.tsx
@@ -7,9 +7,9 @@ import type {
   Project,
   User,
   Version,
+  StatusOption,
 } from "../types";
 import {
-  statusDisplayNames,
   IssueType,
   issueTypeDisplayNames,
   getPriorityDisplayName,
@@ -30,7 +30,7 @@ interface IssueFormProps {
   users: User[];
   currentUserId: string | null;
   currentUserName: string | null;
-  statuses: StatusEnum[];
+  statuses: StatusOption[];
   priorities: PriorityEnum[];
 }
 
@@ -53,7 +53,9 @@ export const IssueForm: React.FC<IssueFormProps> = ({
   const [reporterName, setReporterName] = useState("");
   const [assignee, setAssignee] = useState("");
   const [comment, setComment] = useState("");
-  const [status, setStatus] = useState<StatusEnum>(statuses[0]);
+  const [status, setStatus] = useState<StatusEnum>(
+    statuses[0] ? statuses[0].id : ""
+  );
   const [type, setType] = useState<TypeEnum>(IssueType.TASK); // Default to TASK
   const [priority, setPriority] = useState<PriorityEnum>(priorities[0]);
   const [affectsVersion, setAffectsVersion] = useState("");
@@ -76,7 +78,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
       setReporterName(reporterUser ? reporterUser.username : "");
       setAssignee(initialData.assignee || "");
       setComment(initialData.comment || "");
-      setStatus(initialData.status || statuses[0]);
+      setStatus(initialData.status || (statuses[0]?.id || ""));
       setType(initialData.type || IssueType.TASK);
       setPriority(initialData.priority || priorities[0]);
       setAffectsVersion(initialData.affectsVersion || "");
@@ -92,7 +94,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
       setReporterName(currentUserName || "");
       setAssignee("");
       setComment("");
-      setStatus(statuses[0]);
+      setStatus(statuses[0]?.id || "");
       setType(IssueType.TASK); // Default for new issues
       setPriority(priorities[0]);
       setAffectsVersion("");
@@ -348,8 +350,8 @@ export const IssueForm: React.FC<IssueFormProps> = ({
               disabled={isSubmitting}
             >
               {statuses.map((st) => (
-                <option key={st} value={st}>
-                  {statusDisplayNames[st] || st}
+                <option key={st.id} value={st.id}>
+                  {st.name}
                 </option>
               ))}
             </select>

--- a/frontend-issue-tracker/src/components/IssueHistoryModal.tsx
+++ b/frontend-issue-tracker/src/components/IssueHistoryModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IssueHistoryEntry, User, statusDisplayNames } from '../types';
+import { IssueHistoryEntry, User } from '../types';
 import { Modal } from './Modal';
 import { UserAvatarPlaceholderIcon } from "./icons/UserAvatarPlaceholderIcon";
 
@@ -27,7 +27,7 @@ export const IssueHistoryModal: React.FC<Props> = ({ isOpen, onClose, history, u
       actionLabel = "이슈 생성";
     } else if (entry.action === "updated" && entry.fromStatus && entry.toStatus) {
       actionLabel = "상태 변경됨";
-      detailText = `${statusDisplayNames[entry.fromStatus] || entry.fromStatus} → ${statusDisplayNames[entry.toStatus] || entry.toStatus}`;
+      detailText = `${entry.fromStatus} → ${entry.toStatus}`;
     } else if (entry.action === "updated") {
       actionLabel = "업데이트됨";
       if (entry.changes && entry.changes.length > 0) {

--- a/frontend-issue-tracker/src/components/IssueList.tsx
+++ b/frontend-issue-tracker/src/components/IssueList.tsx
@@ -1,9 +1,9 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import type { Issue, User } from '../types';
+import type { Issue, User, StatusOption } from '../types';
 import type { ResolutionStatus } from '../types';
-import { statusColors, statusDisplayNames, issueTypeDisplayNames, issueTypeColors } from '../types';
+import { statusColors, issueTypeDisplayNames, issueTypeColors } from '../types';
 import { TrashIcon } from './icons/TrashIcon';
 import { PencilIcon } from './icons/PencilIcon';
 import { EyeIcon } from './icons/EyeIcon';
@@ -19,7 +19,7 @@ interface IssueListProps {
   itemsPerPage: number;
   onPageChange: (page: number) => void;
   users: User[];
-  statuses: ResolutionStatus[];
+  statuses: StatusOption[];
 }
 
 export const IssueList: React.FC<IssueListProps> = ({
@@ -178,7 +178,7 @@ export const IssueList: React.FC<IssueListProps> = ({
                 <span
                   className={`px-2 py-0.5 inline-flex text-xs leading-5 font-semibold rounded-full ${statusColors[issue.status]}`}
                 >
-                  {statusDisplayNames[issue.status]}
+                  {issue.status}
                 </span>
               </td>
               <td className="px-3 py-3 whitespace-nowrap text-sm text-slate-700">
@@ -196,8 +196,8 @@ export const IssueList: React.FC<IssueListProps> = ({
                     aria-label={`${issue.title} 상태 변경`}
                   >
                     {statuses.map((s) => (
-                      <option key={s} value={s}>
-                        {statusDisplayNames[s] || s}
+                      <option key={s.id} value={s.id}>
+                        {s.name}
                       </option>
                     ))}
                   </select>

--- a/frontend-issue-tracker/src/components/ProjectIssueSettings.tsx
+++ b/frontend-issue-tracker/src/components/ProjectIssueSettings.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { DEFAULT_STATUSES, DEFAULT_PRIORITIES } from '../types';
+import { DEFAULT_STATUSES, DEFAULT_PRIORITIES, StatusOption } from '../types';
 
 interface Props {
   projectId: string;
 }
 
 const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
-  const [statuses, setStatuses] = useState<string[]>([]);
+  const [statuses, setStatuses] = useState<StatusOption[]>([]);
   const [priorities, setPriorities] = useState<string[]>([]);
-  const [newStatus, setNewStatus] = useState('');
+  const [newStatus, setNewStatus] = useState<StatusOption>({ id: '', name: '' });
   const [newPriority, setNewPriority] = useState('');
 
   useEffect(() => {
@@ -42,11 +42,28 @@ const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
           {statuses.map((s, idx) => (
             <li key={idx} className="flex space-x-2">
               <input
-                value={s}
+                value={s.id}
                 onChange={(e) =>
-                  setStatuses(statuses.map((v, i) => (i === idx ? e.target.value : v)))
+                  setStatuses(
+                    statuses.map((v, i) =>
+                      i === idx ? { ...v, id: e.target.value } : v
+                    )
+                  )
+                }
+                className="border border-slate-300 rounded px-2 py-1 w-32"
+                placeholder="Key"
+              />
+              <input
+                value={s.name}
+                onChange={(e) =>
+                  setStatuses(
+                    statuses.map((v, i) =>
+                      i === idx ? { ...v, name: e.target.value } : v
+                    )
+                  )
                 }
                 className="border border-slate-300 rounded px-2 py-1 flex-1"
+                placeholder="Name"
               />
               <button
                 onClick={() => setStatuses(statuses.filter((_, i) => i !== idx))}
@@ -59,16 +76,24 @@ const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
         </ul>
         <div className="mt-2 flex space-x-2">
           <input
-            value={newStatus}
-            onChange={(e) => setNewStatus(e.target.value)}
+            value={newStatus.id}
+            onChange={(e) => setNewStatus({ ...newStatus, id: e.target.value })}
+            className="border border-slate-300 rounded px-2 py-1 w-32"
+            placeholder="Key"
+          />
+          <input
+            value={newStatus.name}
+            onChange={(e) =>
+              setNewStatus({ ...newStatus, name: e.target.value })
+            }
             className="border border-slate-300 rounded px-2 py-1 flex-1"
-            placeholder="새 상태"
+            placeholder="Name"
           />
           <button
             onClick={() => {
-              if (newStatus.trim()) {
-                setStatuses([...statuses, newStatus.trim()]);
-                setNewStatus('');
+              if (newStatus.id.trim() && newStatus.name.trim()) {
+                setStatuses([...statuses, { ...newStatus }]);
+                setNewStatus({ id: '', name: '' });
               }
             }}
             className="px-3 py-1 bg-slate-200 rounded"

--- a/frontend-issue-tracker/src/components/TopBar.tsx
+++ b/frontend-issue-tracker/src/components/TopBar.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import type { ViewMode } from "../App";
-import type { ResolutionStatus } from "../types";
-import { statusDisplayNames } from "../types";
+import type { ResolutionStatus, StatusOption } from "../types";
 import { SearchIcon } from "./icons/SearchIcon";
 import { UserAvatarPlaceholderIcon } from "./icons/UserAvatarPlaceholderIcon";
 import { GlobeIcon } from "./icons/GlobeIcon";
@@ -15,7 +14,7 @@ interface TopBarProps {
   onSearchTermChange: (term: string) => void;
   statusFilter: ResolutionStatus | "ALL";
   onStatusFilterChange: (status: ResolutionStatus | "ALL") => void;
-  statuses: ResolutionStatus[];
+  statuses: StatusOption[];
   onCreateIssue: () => void;
   currentUser: string | null;
   isAdmin: boolean;
@@ -98,8 +97,8 @@ export const TopBar: React.FC<TopBarProps> = ({
             >
               <option value="ALL">All Statuses</option>
               {statuses.map((s) => (
-                <option key={s} value={s}>
-                  {statusDisplayNames[s] || s}
+                <option key={s.id} value={s.id}>
+                  {s.name}
                 </option>
               ))}
             </select>

--- a/frontend-issue-tracker/src/types.ts
+++ b/frontend-issue-tracker/src/types.ts
@@ -1,12 +1,18 @@
 
 export type ResolutionStatus = string;
-export const DEFAULT_STATUSES: ResolutionStatus[] = [
-  "OPEN",
-  "IN_PROGRESS",
-  "RESOLVED",
-  "VALIDATING",
-  "CLOSED",
-  "WONT_DO",
+
+export interface StatusOption {
+  id: string;
+  name: string;
+}
+
+export const DEFAULT_STATUSES: StatusOption[] = [
+  { id: "OPEN", name: "열림" },
+  { id: "IN_PROGRESS", name: "수정 중" },
+  { id: "RESOLVED", name: "수정 완료" },
+  { id: "VALIDATING", name: "검증" },
+  { id: "CLOSED", name: "닫힘" },
+  { id: "WONT_DO", name: "원치 않음" },
 ];
 
 export enum IssueType {
@@ -78,7 +84,7 @@ export interface Project {
   id: string;
   name: string;
   key: string;
-  statuses?: ResolutionStatus[];
+  statuses?: StatusOption[];
   priorities?: IssuePriority[];
 }
 
@@ -90,16 +96,6 @@ export const statusColors: Record<string, string> = {
   CLOSED: 'bg-slate-100 text-slate-800 ring-slate-600/20',
   WONT_DO: 'bg-gray-100 text-gray-800 ring-gray-600/20',
 };
-
-export const statusDisplayNames: Record<string, string> = {
-  OPEN: '열림',
-  IN_PROGRESS: '수정 중',
-  RESOLVED: '수정 완료',
-  VALIDATING: '검증',
-  CLOSED: '닫힘',
-  WONT_DO: '원치 않음',
-};
-export const getStatusDisplayName = (s: string) => statusDisplayNames[s] || s;
 
 export const issueTypeDisplayNames: Record<IssueType, string> = {
   [IssueType.TASK]: "작업",
@@ -139,22 +135,6 @@ export interface BoardColumn {
   title: string;
   issues: Issue[];
 }
-
-export const DEFAULT_BOARD_STATUSES: ResolutionStatus[] = [
-  "OPEN",
-  "IN_PROGRESS",
-  "RESOLVED",
-  "VALIDATING",
-];
-
-export const boardStatusToTitleMap: Record<string, string> = {
-  OPEN: statusDisplayNames["OPEN"],
-  IN_PROGRESS: statusDisplayNames["IN_PROGRESS"],
-  RESOLVED: statusDisplayNames["RESOLVED"],
-  VALIDATING: statusDisplayNames["VALIDATING"],
-  CLOSED: statusDisplayNames["CLOSED"],
-  WONT_DO: statusDisplayNames["WONT_DO"],
-};
 
 export interface Version {
   id: string;

--- a/types.ts
+++ b/types.ts
@@ -1,9 +1,9 @@
 
-export enum ResolutionStatus {
-  OPEN = "OPEN",
-  IN_PROGRESS = "IN_PROGRESS",
-  RESOLVED = "RESOLVED",
-  CLOSED = "CLOSED",
+export type ResolutionStatus = string;
+
+export interface StatusOption {
+  id: string;
+  name: string;
 }
 
 export interface Issue {


### PR DESCRIPTION
## Summary
- keep status names alongside status ids instead of using a translation map
- adapt server and migration logic for the new format
- update frontend components to use the new `StatusOption` type
- let project settings edit status key/name pairs

## Testing
- `npm run lint --prefix frontend-issue-tracker` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68621a498580832ea0e370d165a1ae2e