### PR TITLE
Add resolution modal feature

### DIFF
--- a/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
@@ -189,6 +189,7 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
           />
           <DetailItem label="영향을 받는 버전" value={issue.affectsVersion} />
           <DetailItem label="수정 버전" value={issue.fixVersion} />
+          <DetailItem label="해결 사유" value={issue.resolution} />
           <DetailItem
             label="생성일시"
             value={formattedDate}

--- a/frontend-issue-tracker/src/components/IssueDetailsView.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailsView.tsx
@@ -115,6 +115,7 @@ export const IssueDetailsView: React.FC<IssueDetailsViewProps> = ({ issue, users
         <DetailItem label="생성일시" value={formattedDate} />
         <DetailItem label="수정일시" value={formattedUpdated} />
         {formattedResolved && <DetailItem label="해결일시" value={formattedResolved} />}
+        {issue.resolution && <DetailItem label="해결 사유" value={issue.resolution} />}
         {issue.attachments && issue.attachments.length > 0 && (
           <DetailItem
             label="첨부 파일"

--- a/frontend-issue-tracker/src/components/ProjectIssueSettings.tsx
+++ b/frontend-issue-tracker/src/components/ProjectIssueSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { DEFAULT_PRIORITIES } from '../types';
+import { DEFAULT_PRIORITIES, DEFAULT_RESOLUTIONS } from '../types';
 
 interface Props {
   projectId: string;
@@ -8,8 +8,10 @@ interface Props {
 const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
   const [statuses, setStatuses] = useState<string[]>([]);
   const [priorities, setPriorities] = useState<string[]>([]);
+  const [resolutions, setResolutions] = useState<string[]>([]);
   const [newStatus, setNewStatus] = useState('');
   const [newPriority, setNewPriority] = useState('');
+  const [newResolution, setNewResolution] = useState('');
 
   useEffect(() => {
     const fetchSettings = async () => {
@@ -18,9 +20,11 @@ const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
         const data = await res.json();
         setStatuses(data.statuses || []);
         setPriorities(data.priorities || DEFAULT_PRIORITIES);
+        setResolutions(data.resolutions || ["완료", "원하지 않음", "재현 불가"]);
       } else {
         setStatuses([]);
         setPriorities(DEFAULT_PRIORITIES);
+        setResolutions(DEFAULT_RESOLUTIONS);
       }
     };
     fetchSettings();
@@ -30,7 +34,7 @@ const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
     await fetch(`/api/projects/${projectId}/issue-settings`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ statuses, priorities }),
+      body: JSON.stringify({ statuses, priorities, resolutions }),
     });
   };
 
@@ -112,6 +116,49 @@ const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
               if (newPriority.trim()) {
                 setPriorities([...priorities, newPriority.trim()]);
                 setNewPriority('');
+              }
+            }}
+            className="px-3 py-1 bg-slate-200 rounded"
+          >
+            추가
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="font-semibold mb-2">Resolution Reasons</h3>
+        <ul className="space-y-2">
+          {resolutions.map((r, idx) => (
+            <li key={idx} className="flex space-x-2">
+              <input
+                value={r}
+                onChange={(e) =>
+                  setResolutions(resolutions.map((v, i) => (i === idx ? e.target.value : v)))
+                }
+                className="border border-slate-300 rounded px-2 py-1 flex-1"
+                placeholder="해결 사유"
+              />
+              <button
+                onClick={() => setResolutions(resolutions.filter((_, i) => i !== idx))}
+                className="text-red-600 px-2"
+              >
+                삭제
+              </button>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-2 flex space-x-2">
+          <input
+            value={newResolution}
+            onChange={(e) => setNewResolution(e.target.value)}
+            className="border border-slate-300 rounded px-2 py-1 flex-1"
+            placeholder="새 해결 사유"
+          />
+          <button
+            onClick={() => {
+              if (newResolution.trim()) {
+                setResolutions([...resolutions, newResolution.trim()]);
+                setNewResolution('');
               }
             }}
             className="px-3 py-1 bg-slate-200 rounded"

--- a/frontend-issue-tracker/src/components/ResolveIssueModal.tsx
+++ b/frontend-issue-tracker/src/components/ResolveIssueModal.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useState } from 'react';
+import { Modal } from './Modal';
+import type { User, Version } from '../types';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: {
+    assignee?: string;
+    resolution: string;
+    fixVersion?: string;
+    attachments: File[];
+    comment?: string;
+  }) => void;
+  projectId: string;
+  users: User[];
+  resolutions: string[];
+  initialAssignee?: string;
+}
+
+export const ResolveIssueModal: React.FC<Props> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  projectId,
+  users,
+  resolutions,
+  initialAssignee,
+}) => {
+  const [assignee, setAssignee] = useState(initialAssignee || '');
+  const [resolution, setResolution] = useState(resolutions[0] || '');
+  const [fixVersion, setFixVersion] = useState('');
+  const [attachments, setAttachments] = useState<File[]>([]);
+  const [comment, setComment] = useState('');
+  const [versions, setVersions] = useState<Version[]>([]);
+
+  useEffect(() => {
+    if (projectId) {
+      fetch(`/api/projects/${projectId}/versions`)
+        .then((res) => (res.ok ? res.json() : []))
+        .then((data) => setVersions(data as Version[]))
+        .catch(() => setVersions([]));
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    setAssignee(initialAssignee || '');
+  }, [initialAssignee]);
+
+  useEffect(() => {
+    if (resolutions && resolutions.length > 0) {
+      setResolution(resolutions[0]);
+    }
+  }, [resolutions]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ assignee, resolution, fixVersion, attachments, comment });
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="수정 완료 정보">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1" htmlFor="resolve-assignee">
+            담당자
+          </label>
+          <select
+            id="resolve-assignee"
+            value={assignee}
+            onChange={(e) => setAssignee(e.target.value)}
+            className="mt-1 block w-full shadow-sm sm:text-sm border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 py-2 px-3"
+          >
+            <option value="">미지정</option>
+            {users.map((u) => (
+              <option key={u.userid} value={u.userid}>
+                {u.username}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1" htmlFor="resolve-reason">
+            해결 사유
+          </label>
+          <select
+            id="resolve-reason"
+            value={resolution}
+            onChange={(e) => setResolution(e.target.value)}
+            className="mt-1 block w-full shadow-sm sm:text-sm border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 py-2 px-3"
+            required
+          >
+            {resolutions.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1" htmlFor="resolve-fixVersion">
+            수정 버전
+          </label>
+          <select
+            id="resolve-fixVersion"
+            value={fixVersion}
+            onChange={(e) => setFixVersion(e.target.value)}
+            className="mt-1 block w-full shadow-sm sm:text-sm border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 py-2 px-3"
+          >
+            <option value="">선택 없음</option>
+            {versions.map((v) => (
+              <option key={v.id} value={v.name}>
+                {v.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1" htmlFor="resolve-files">
+            첨부 파일
+          </label>
+          <input
+            id="resolve-files"
+            type="file"
+            multiple
+            onChange={(e) => setAttachments(Array.from(e.target.files || []))}
+            className="mt-1 block w-full text-sm text-slate-700"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1" htmlFor="resolve-comment">
+            댓글
+          </label>
+          <textarea
+            id="resolve-comment"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            rows={3}
+            className="mt-1 block w-full shadow-sm sm:text-sm border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500"
+          />
+        </div>
+
+        <div className="flex justify-end space-x-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-slate-700 bg-slate-100 border border-slate-300 rounded-md hover:bg-slate-200"
+          >
+            취소
+          </button>
+          <button
+            type="submit"
+            className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 border border-transparent rounded-md"
+          >
+            저장
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default ResolveIssueModal;

--- a/frontend-issue-tracker/src/types.ts
+++ b/frontend-issue-tracker/src/types.ts
@@ -17,6 +17,11 @@ export const DEFAULT_PRIORITIES: IssuePriority[] = [
   "LOW",
   "LOWEST",
 ];
+export const DEFAULT_RESOLUTIONS: string[] = [
+  "완료",
+  "원하지 않음",
+  "재현 불가",
+];
 
 export interface Issue {
   id: string;
@@ -31,6 +36,7 @@ export interface Issue {
   createdAt: string; // ISO date string
   updatedAt: string; // ISO date string
   resolvedAt?: string; // ISO date string when issue is resolved/closed
+  resolution?: string;
   type: IssueType; // New
   priority: IssuePriority;
   affectsVersion?: string; // New
@@ -73,6 +79,7 @@ export interface Project {
   key: string;
   statuses?: string[];
   priorities?: IssuePriority[];
+  resolutions?: string[];
 }
 
 export const statusColors: Record<string, string> = {

--- a/types.ts
+++ b/types.ts
@@ -1,6 +1,12 @@
 
 export type ResolutionStatus = string;
 
+export const DEFAULT_RESOLUTIONS: string[] = [
+  "완료",
+  "원하지 않음",
+  "재현 불가",
+];
+
 export interface StatusOption {
   id: string;
   name: string;
@@ -17,6 +23,7 @@ export interface Issue {
   createdAt: string; // ISO date string
   updatedAt: string; // ISO date string
   resolvedAt?: string; // ISO date string when issue is resolved/closed
+  resolution?: string;
   history?: IssueHistoryEntry[];
 }
 


### PR DESCRIPTION
## Summary
- support default resolution reasons at server level
- store resolutions in project settings and expose via API
- include resolution when creating or updating issues
- add project settings UI for resolutions
- add ResolveIssueModal component
- update issue detail views to show resolution
- open the modal when changing status to `수정 완료`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6862397c71d0832ebe88b6aa1753a797