### PR TITLE
Add component settings for issues

### DIFF
--- a/frontend-issue-tracker/src/App.tsx
+++ b/frontend-issue-tracker/src/App.tsx
@@ -35,6 +35,7 @@ export type IssueFormData = {
   status?: StatusEnum; // Only for edit
   type: string; // New, mandatory
   priority: PriorityEnum;
+  component?: string;
   affectsVersion?: string; // New
   fixVersion?: string; // New, only for edit
   projectId: string;
@@ -819,6 +820,7 @@ const App: React.FC = () => {
           statuses={currentProject?.statuses || []}
           priorities={currentProject?.priorities || DEFAULT_PRIORITIES}
           types={currentProject?.types || DEFAULT_ISSUE_TYPES}
+          components={currentProject?.components || []}
         />
       </Modal>
 
@@ -871,6 +873,10 @@ const App: React.FC = () => {
             types={
               projects.find((p) => p.id === selectedIssueForEdit.projectId)?.types ||
               DEFAULT_ISSUE_TYPES
+            }
+            components={
+              projects.find((p) => p.id === selectedIssueForEdit.projectId)?.components ||
+              []
             }
           />
         </Modal>

--- a/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
@@ -182,6 +182,7 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
                   : undefined
               }
             />
+            <DetailItem label="컴포넌트" value={issue.component} />
             <DetailItem label="영향을 받는 버전" value={issue.affectsVersion} />
             <DetailItem label="수정 버전" value={issue.fixVersion} />
             <DetailItem label="해결 사유" value={issue.resolution} />

--- a/frontend-issue-tracker/src/components/IssueForm.tsx
+++ b/frontend-issue-tracker/src/components/IssueForm.tsx
@@ -27,6 +27,7 @@ interface IssueFormProps {
   statuses: string[];
   priorities: PriorityEnum[];
   types: string[];
+  components: string[];
 }
 
 interface TypeOption {
@@ -50,6 +51,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
   statuses,
   priorities,
   types,
+  components,
 }) => {
   const [content, setContent] = useState("");
   const [title, setTitle] = useState("");
@@ -62,6 +64,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
   );
   const [type, setType] = useState<string>(types[0] || DEFAULT_ISSUE_TYPES[0]);
   const [priority, setPriority] = useState<PriorityEnum>(priorities[0]);
+  const [componentValue, setComponentValue] = useState("");
   const [affectsVersion, setAffectsVersion] = useState("");
   const [fixVersion, setFixVersion] = useState("");
   const [projectId, setProjectId] = useState<string>("");
@@ -122,6 +125,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
       setStatus(initialData.status || statuses[0] || "");
       setType(initialData.type || types[0] || DEFAULT_ISSUE_TYPES[0]);
       setPriority(initialData.priority || priorities[0]);
+      setComponentValue(initialData.component || "");
       setAffectsVersion(initialData.affectsVersion || "");
       setFixVersion(initialData.fixVersion || "");
       setProjectId(
@@ -138,6 +142,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
       setStatus(statuses[0] || "");
       setType(types[0] || DEFAULT_ISSUE_TYPES[0]);
       setPriority(priorities[0]);
+      setComponentValue("");
       setAffectsVersion("");
       setFixVersion("");
       setProjectId(selectedProjectId || projects[0]?.id || "");
@@ -197,6 +202,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
         comment: comment.trim() || undefined,
         type: type,
         priority: priority,
+        component: componentValue.trim() || undefined,
         affectsVersion: affectsVersion.trim() || undefined,
         projectId,
         attachments,
@@ -320,6 +326,29 @@ export const IssueForm: React.FC<IssueFormProps> = ({
             <p className="mt-1 text-xs text-red-600">{typeError}</p>
           )}
         </div>
+      </div>
+
+      <div>
+        <label
+          htmlFor="issue-component"
+          className="block text-sm font-medium text-slate-700 mb-1"
+        >
+          컴포넌트
+        </label>
+        <select
+          id="issue-component"
+          value={componentValue}
+          onChange={(e) => setComponentValue(e.target.value)}
+          className="mt-1 block w-full shadow-sm sm:text-sm border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 py-2 px-3"
+          disabled={isSubmitting}
+        >
+          <option value="">선택 없음</option>
+          {components.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
       </div>
 
       <div>

--- a/frontend-issue-tracker/src/components/ProjectIssueSettings.tsx
+++ b/frontend-issue-tracker/src/components/ProjectIssueSettings.tsx
@@ -12,12 +12,14 @@ const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
   const [priorities, setPriorities] = useState<string[]>([]);
   const [resolutions, setResolutions] = useState<string[]>([]);
   const [types, setTypes] = useState<string[]>([]);
+  const [components, setComponents] = useState<string[]>([]);
 
   // 변경 여부(isDirty)를 확인하기 위한 초기 상태
   const [initialStatuses, setInitialStatuses] = useState<string[]>([]);
   const [initialPriorities, setInitialPriorities] = useState<string[]>([]);
   const [initialResolutions, setInitialResolutions] = useState<string[]>([]);
   const [initialTypes, setInitialTypes] = useState<string[]>([]);
+  const [initialComponents, setInitialComponents] = useState<string[]>([]);
 
   // UI 상태
   const [isLoading, setIsLoading] = useState(true);
@@ -35,21 +37,25 @@ const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
           setPriorities(data.priorities || DEFAULT_PRIORITIES);
           setResolutions(data.resolutions || DEFAULT_RESOLUTIONS);
           setTypes(data.types || DEFAULT_ISSUE_TYPES);
+          setComponents(data.components || []);
 
           setInitialStatuses(data.statuses || []);
           setInitialPriorities(data.priorities || DEFAULT_PRIORITIES);
           setInitialResolutions(data.resolutions || DEFAULT_RESOLUTIONS);
           setInitialTypes(data.types || DEFAULT_ISSUE_TYPES);
+          setInitialComponents(data.components || []);
         } else {
           // API 실패 시 기본값으로 설정
           setStatuses([]);
           setPriorities(DEFAULT_PRIORITIES);
           setResolutions(DEFAULT_RESOLUTIONS);
           setTypes(DEFAULT_ISSUE_TYPES);
+          setComponents([]);
           setInitialStatuses([]);
           setInitialPriorities(DEFAULT_PRIORITIES);
           setInitialResolutions(DEFAULT_RESOLUTIONS);
           setInitialTypes(DEFAULT_ISSUE_TYPES);
+          setInitialComponents([]);
         }
       } catch (error) {
         console.error("Failed to fetch settings:", error);
@@ -66,7 +72,7 @@ const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
       const res = await fetch(`/api/projects/${projectId}/issue-settings`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ statuses, priorities, resolutions, types }),
+        body: JSON.stringify({ statuses, priorities, resolutions, types, components }),
       });
 
       if (res.ok) {
@@ -75,6 +81,7 @@ const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
         setInitialPriorities(priorities);
         setInitialResolutions(resolutions);
         setInitialTypes(types);
+        setInitialComponents(components);
       } else {
         // 에러 처리 (예: 사용자에게 Toast 알림)
         console.error("Failed to save settings");
@@ -91,7 +98,8 @@ const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
     JSON.stringify(statuses) !== JSON.stringify(initialStatuses) ||
     JSON.stringify(priorities) !== JSON.stringify(initialPriorities) ||
     JSON.stringify(resolutions) !== JSON.stringify(initialResolutions) ||
-    JSON.stringify(types) !== JSON.stringify(initialTypes);
+    JSON.stringify(types) !== JSON.stringify(initialTypes) ||
+    JSON.stringify(components) !== JSON.stringify(initialComponents);
 
   if (isLoading) {
     return <div className="p-4">Loading settings...</div>;
@@ -112,6 +120,12 @@ const ProjectIssueSettings: React.FC<Props> = ({ projectId }) => {
           items={types}
           setItems={setTypes}
           placeholder="새 유형"
+        />
+        <EditableList
+          title="Components"
+          items={components}
+          setItems={setComponents}
+          placeholder="새 컴포넌트"
         />
         <EditableList
           title="Issue Priorities"

--- a/frontend-issue-tracker/src/types.ts
+++ b/frontend-issue-tracker/src/types.ts
@@ -38,6 +38,7 @@ export interface Issue {
   resolution?: string;
   type: IssueType; // New
   priority: IssuePriority;
+  component?: string;
   affectsVersion?: string; // New
   fixVersion?: string; // New
   projectId: string;
@@ -80,6 +81,7 @@ export interface Project {
   priorities?: IssuePriority[];
   resolutions?: string[];
   types?: IssueType[];
+  components?: string[];
 }
 
 export const statusColors: Record<string, string> = {


### PR DESCRIPTION
## Summary
- add components field on projects and issues backend
- expose components editing in project settings
- allow selecting component when creating or editing an issue
- display component in issue details

## Testing
- `npm --prefix frontend-issue-tracker run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c243da88832eb7e4a5b4454be517