### PR TITLE
Add customer management in project settings

### DIFF
--- a/frontend-issue-tracker/src/App.tsx
+++ b/frontend-issue-tracker/src/App.tsx
@@ -36,6 +36,7 @@ export type IssueFormData = {
   type: string; // New, mandatory
   priority: PriorityEnum;
   component?: string;
+  customer?: string;
   affectsVersion?: string; // New
   fixVersion?: string; // New, only for edit
   projectId: string;
@@ -821,6 +822,9 @@ const App: React.FC = () => {
           priorities={currentProject?.priorities || DEFAULT_PRIORITIES}
           types={currentProject?.types || DEFAULT_ISSUE_TYPES}
           components={currentProject?.components || []}
+          customers={currentProject?.customers || []}
+          showCustomers={currentProject?.showCustomers}
+          showComponents={currentProject?.showComponents}
         />
       </Modal>
 
@@ -877,6 +881,16 @@ const App: React.FC = () => {
             components={
               projects.find((p) => p.id === selectedIssueForEdit.projectId)?.components ||
               []
+            }
+            customers={
+              projects.find((p) => p.id === selectedIssueForEdit.projectId)?.customers ||
+              []
+            }
+            showCustomers={
+              projects.find((p) => p.id === selectedIssueForEdit.projectId)?.showCustomers
+            }
+            showComponents={
+              projects.find((p) => p.id === selectedIssueForEdit.projectId)?.showComponents
             }
           />
         </Modal>

--- a/frontend-issue-tracker/src/ProjectSettingsPage.tsx
+++ b/frontend-issue-tracker/src/ProjectSettingsPage.tsx
@@ -4,6 +4,8 @@ import ProjectSettingsSidebar from './components/ProjectSettingsSidebar';
 import ProjectVersions from './components/ProjectVersions';
 import ProjectIssueSettings from './components/ProjectIssueSettings';
 import ProjectComponents from './components/ProjectComponents';
+import ProjectCustomers from './components/ProjectCustomers';
+import ProjectDetails from './components/ProjectDetails';
 import type { User } from './types';
 
 interface LocationState {
@@ -48,9 +50,21 @@ export const ProjectSettingsPage: React.FC = () => {
       />
       <main className="flex-1 p-6 overflow-auto">
         <h2 className="text-xl font-semibold mb-4">{activeSection}</h2>
-        {activeSection === '버전' ? (
+        {activeSection === '세부사항' ? (
+          projectId ? (
+            <ProjectDetails projectId={projectId} />
+          ) : (
+            <div>프로젝트 ID가 없습니다.</div>
+          )
+        ) : activeSection === '버전' ? (
           projectId ? (
             <ProjectVersions projectId={projectId} users={users} currentUserId={currentUserId} />
+          ) : (
+            <div>프로젝트 ID가 없습니다.</div>
+          )
+        ) : activeSection === '고객사' ? (
+          projectId ? (
+            <ProjectCustomers projectId={projectId} users={users} />
           ) : (
             <div>프로젝트 ID가 없습니다.</div>
           )

--- a/frontend-issue-tracker/src/components/CustomerForm.tsx
+++ b/frontend-issue-tracker/src/components/CustomerForm.tsx
@@ -1,0 +1,131 @@
+import React, { useState, useEffect } from "react";
+import type { User, Customer } from "../types";
+
+interface CustomerFormProps {
+  initialData?: Partial<Customer>;
+  onSubmit: (data: Partial<Customer>) => Promise<void>;
+  onCancel: () => void;
+  users: User[];
+  submitText?: string;
+}
+
+export const CustomerForm: React.FC<CustomerFormProps> = ({
+  initialData,
+  onSubmit,
+  onCancel,
+  users,
+  submitText = "저장",
+}) => {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [owners, setOwners] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (initialData) {
+      setName(initialData.name || "");
+      setDescription(initialData.description || "");
+      setOwners(initialData.owners || []);
+    } else {
+      setName("");
+      setDescription("");
+      setOwners([]);
+    }
+  }, [initialData]);
+
+  const handleOwnerChange = (userId: string) => {
+    setOwners((prev) =>
+      prev.includes(userId)
+        ? prev.filter((id) => id !== userId)
+        : [...prev, userId]
+    );
+  };
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    onSubmit({
+      name: name.trim(),
+      description: description.trim() || undefined,
+      owners,
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div>
+        <label
+          htmlFor="comp-name"
+          className="block text-sm font-medium text-slate-700 mb-1"
+        >
+          고객사 이름 <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="comp-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="mt-1 block w-full shadow-sm sm:text-sm border-slate-300 rounded-md py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
+          required
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="comp-desc"
+          className="block text-sm font-medium text-slate-700 mb-1"
+        >
+          설명
+        </label>
+        <textarea
+          id="comp-desc"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={3}
+          className="mt-1 block w-full shadow-sm sm:text-sm border-slate-300 rounded-md py-2 px-3 focus:ring-indigo-500 focus:border-indigo-500"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-slate-700 mb-1">
+          담당자
+        </label>
+        <div className="mt-2 p-3 border border-slate-300 rounded-md max-h-60 overflow-y-auto space-y-2 bg-slate-50/50">
+          {users.length > 0 ? (
+            users.map((user) => (
+              <label
+                key={user.userid}
+                className="flex items-center space-x-3 p-2 rounded-md hover:bg-slate-100 cursor-pointer transition-colors"
+              >
+                <input
+                  type="checkbox"
+                  checked={owners.includes(user.userid)}
+                  onChange={() => handleOwnerChange(user.userid)}
+                  className="h-4 w-4 rounded border-slate-400 text-indigo-600 focus:ring-indigo-500"
+                />
+                <span className="text-sm text-slate-800">{user.username}</span>
+              </label>
+            ))
+          ) : (
+            <p className="text-sm text-slate-500 text-center py-4">
+              담당자로 지정할 사용자가 없습니다.
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="flex justify-end space-x-3 pt-4 border-t border-slate-200">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 text-sm font-medium text-slate-700 bg-white hover:bg-slate-50 border border-slate-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+        >
+          취소
+        </button>
+        <button
+          type="submit"
+          className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 border border-transparent rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+        >
+          {submitText}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default CustomerForm;

--- a/frontend-issue-tracker/src/components/IssueForm.tsx
+++ b/frontend-issue-tracker/src/components/IssueForm.tsx
@@ -28,6 +28,9 @@ interface IssueFormProps {
   priorities: PriorityEnum[];
   types: string[];
   components: string[];
+  customers: string[];
+  showCustomers?: boolean;
+  showComponents?: boolean;
 }
 
 interface TypeOption {
@@ -52,6 +55,9 @@ export const IssueForm: React.FC<IssueFormProps> = ({
   priorities,
   types,
   components,
+  customers,
+  showCustomers = true,
+  showComponents = true,
 }) => {
   const [content, setContent] = useState("");
   const [title, setTitle] = useState("");
@@ -65,6 +71,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
   const [type, setType] = useState<string>(types[0] || DEFAULT_ISSUE_TYPES[0]);
   const [priority, setPriority] = useState<PriorityEnum>(priorities[0]);
   const [componentValue, setComponentValue] = useState("");
+  const [customerValue, setCustomerValue] = useState("");
   const [affectsVersion, setAffectsVersion] = useState("");
   const [fixVersion, setFixVersion] = useState("");
   const [projectId, setProjectId] = useState<string>("");
@@ -126,6 +133,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
       setType(initialData.type || types[0] || DEFAULT_ISSUE_TYPES[0]);
       setPriority(initialData.priority || priorities[0]);
       setComponentValue(initialData.component || "");
+      setCustomerValue(initialData.customer || "");
       setAffectsVersion(initialData.affectsVersion || "");
       setFixVersion(initialData.fixVersion || "");
       setProjectId(
@@ -143,6 +151,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
       setType(types[0] || DEFAULT_ISSUE_TYPES[0]);
       setPriority(priorities[0]);
       setComponentValue("");
+      setCustomerValue("");
       setAffectsVersion("");
       setFixVersion("");
       setProjectId(selectedProjectId || projects[0]?.id || "");
@@ -203,6 +212,7 @@ export const IssueForm: React.FC<IssueFormProps> = ({
         type: type,
         priority: priority,
         component: componentValue.trim() || undefined,
+        customer: customerValue.trim() || undefined,
         affectsVersion: affectsVersion.trim() || undefined,
         projectId,
         attachments,
@@ -328,28 +338,55 @@ export const IssueForm: React.FC<IssueFormProps> = ({
         </div>
       </div>
 
-      <div>
-        <label
-          htmlFor="issue-component"
-          className="block text-sm font-medium text-slate-700 mb-1"
-        >
-          컴포넌트
-        </label>
-        <select
-          id="issue-component"
-          value={componentValue}
-          onChange={(e) => setComponentValue(e.target.value)}
-          className="mt-1 block w-full shadow-sm sm:text-sm border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 py-2 px-3"
-          disabled={isSubmitting}
-        >
-          <option value="">선택 없음</option>
-          {components.map((c) => (
-            <option key={c} value={c}>
-              {c}
-            </option>
-          ))}
-        </select>
-      </div>
+      {showCustomers && (
+        <div>
+          <label
+            htmlFor="issue-customer"
+            className="block text-sm font-medium text-slate-700 mb-1"
+          >
+            고객사
+          </label>
+          <select
+            id="issue-customer"
+            value={customerValue}
+            onChange={(e) => setCustomerValue(e.target.value)}
+            className="mt-1 block w-full shadow-sm sm:text-sm border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 py-2 px-3"
+            disabled={isSubmitting}
+          >
+            <option value="">선택 없음</option>
+            {customers.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {showComponents && (
+        <div>
+          <label
+            htmlFor="issue-component"
+            className="block text-sm font-medium text-slate-700 mb-1"
+          >
+            컴포넌트
+          </label>
+          <select
+            id="issue-component"
+            value={componentValue}
+            onChange={(e) => setComponentValue(e.target.value)}
+            className="mt-1 block w-full shadow-sm sm:text-sm border-slate-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 py-2 px-3"
+            disabled={isSubmitting}
+          >
+            <option value="">선택 없음</option>
+            {components.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       <div>
         <label

--- a/frontend-issue-tracker/src/components/ProjectCustomers.tsx
+++ b/frontend-issue-tracker/src/components/ProjectCustomers.tsx
@@ -1,0 +1,190 @@
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import { Modal } from "./Modal";
+import { ConfirmationModal } from "./ConfirmationModal";
+import CustomerForm from "./CustomerForm";
+import type { Customer, User } from "../types";
+import { EllipsisVerticalIcon } from "./icons/EllipsisVerticalIcon";
+
+interface ActionMenuProps {
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+const ActionMenu: React.FC<ActionMenuProps> = ({ onEdit, onDelete }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  return (
+    <div className="relative inline-block" ref={ref}>
+      <button
+        type="button"
+        className="flex items-center text-slate-400 hover:text-slate-600 p-1 rounded-full hover:bg-slate-100"
+        onClick={() => setOpen(!open)}
+      >
+        <EllipsisVerticalIcon className="h-5 w-5" />
+      </button>
+      {open && (
+        <div className="origin-top-right absolute right-0 mt-2 w-40 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-10">
+          <div className="py-1">
+            <button
+              onClick={() => {
+                onEdit();
+                setOpen(false);
+              }}
+              className="block w-full text-left px-4 py-2 text-sm text-slate-700 hover:bg-slate-100"
+            >
+              수정
+            </button>
+            <button
+              onClick={() => {
+                onDelete();
+                setOpen(false);
+              }}
+              className="block w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-red-50"
+            >
+              삭제
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface Props {
+  projectId: string;
+  users: User[];
+}
+
+export const ProjectCustomers: React.FC<Props> = ({ projectId, users }) => {
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [showModal, setShowModal] = useState(false);
+  const [editCustomer, setEditCustomer] = useState<Customer | null>(null);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+
+  const fetchComponents = useCallback(async () => {
+    const res = await fetch(`/api/projects/${projectId}/customers`);
+    if (res.ok) {
+      const data: Customer[] = await res.json();
+      setCustomers(data);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    fetchComponents();
+  }, [fetchComponents]);
+
+  const handleSave = async (data: Partial<Component>) => {
+    if (editCustomer) {
+      await fetch(`/api/customers/${editCustomer.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+    } else {
+      await fetch(`/api/projects/${projectId}/customers`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+    }
+    setShowModal(false);
+    setEditCustomer(null);
+    fetchComponents();
+  };
+
+  const handleDelete = async () => {
+    if (!deleteId) return;
+    await fetch(`/api/customers/${deleteId}`, { method: "DELETE" });
+    setDeleteId(null);
+    fetchComponents();
+  };
+
+  return (
+    <div>
+      <button
+        onClick={() => setShowModal(true)}
+        className="mb-4 px-3 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-md"
+      >
+        고객사 만들기
+      </button>
+      <table className="min-w-full divide-y divide-slate-200 text-sm">
+        <thead>
+          <tr className="bg-slate-50">
+            <th className="px-3 py-2 text-left font-semibold">고객사</th>
+            <th className="px-3 py-2 text-left font-semibold">설명</th>
+            <th className="px-3 py-2 text-left font-semibold">담당자</th>
+            <th className="px-3 py-2 text-center font-semibold">이슈</th>
+            <th className="px-3 py-2 text-center font-semibold">추가 작업</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-200">
+          {customers.map((c) => (
+            <tr key={c.id}>
+              <td className="px-3 py-2 whitespace-nowrap">{c.name}</td>
+              <td className="px-3 py-2 whitespace-nowrap">
+                {c.description || "-"}
+              </td>
+              <td className="px-3 py-2 whitespace-nowrap">
+                {c.owners
+                  .map((o) => users.find((u) => u.userid === o)?.username || o)
+                  .join(", ") || "-"}
+              </td>
+              <td className="px-3 py-2 whitespace-nowrap text-center">
+                {c.issueCount ?? 0}
+              </td>
+              <td className="px-3 py-2 whitespace-nowrap text-center">
+                <ActionMenu
+                  onEdit={() => {
+                    setEditCustomer(c);
+                    setShowModal(true);
+                  }}
+                  onDelete={() => setDeleteId(c.id)}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <Modal
+        isOpen={showModal}
+        onClose={() => {
+          setShowModal(false);
+          setEditCustomer(null);
+        }}
+        title="고객사"
+      >
+        <CustomerForm
+          initialData={editCustomer || undefined}
+          onSubmit={handleSave}
+          onCancel={() => {
+            setShowModal(false);
+            setEditCustomer(null);
+          }}
+          users={users}
+          submitText={editCustomer ? "저장" : "생성"}
+        />
+      </Modal>
+      {deleteId && (
+        <ConfirmationModal
+          title="고객사 삭제"
+          message="선택한 고객사를 삭제하시겠습니까?"
+          onConfirm={handleDelete}
+          onCancel={() => setDeleteId(null)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ProjectCustomers;

--- a/frontend-issue-tracker/src/components/ProjectDetails.tsx
+++ b/frontend-issue-tracker/src/components/ProjectDetails.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+
+interface Props {
+  projectId: string;
+}
+
+const ProjectDetails: React.FC<Props> = ({ projectId }) => {
+  const [showCustomers, setShowCustomers] = useState(true);
+  const [showComponents, setShowComponents] = useState(true);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const res = await fetch(`/api/projects/${projectId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setShowCustomers(data.showCustomers !== false);
+        setShowComponents(data.showComponents !== false);
+      }
+      setLoading(false);
+    };
+    fetchData();
+  }, [projectId]);
+
+  const handleSave = async () => {
+    await fetch(`/api/projects/${projectId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ showCustomers, showComponents }),
+    });
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          id="show-customers"
+          checked={showCustomers}
+          onChange={(e) => setShowCustomers(e.target.checked)}
+        />
+        <label htmlFor="show-customers">고객사 노출 여부</label>
+      </div>
+      <div className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          id="show-components"
+          checked={showComponents}
+          onChange={(e) => setShowComponents(e.target.checked)}
+        />
+        <label htmlFor="show-components">컴포넌트 노출 여부</label>
+      </div>
+      <button
+        onClick={handleSave}
+        className="px-4 py-2 bg-indigo-600 text-white rounded-md"
+      >
+        저장
+      </button>
+    </div>
+  );
+};
+
+export default ProjectDetails;

--- a/frontend-issue-tracker/src/components/ProjectSettingsSidebar.tsx
+++ b/frontend-issue-tracker/src/components/ProjectSettingsSidebar.tsx
@@ -8,7 +8,7 @@ interface Props {
   onBack: () => void;
 }
 
-const menuItems = ['세부사항', '알림', '버전', '컴포넌트', '이슈 설정'];
+const menuItems = ['세부사항', '알림', '버전', '고객사', '컴포넌트', '이슈 설정'];
 
 export const ProjectSettingsSidebar: React.FC<Props> = ({
   projectName,

--- a/frontend-issue-tracker/src/types.ts
+++ b/frontend-issue-tracker/src/types.ts
@@ -39,6 +39,7 @@ export interface Issue {
   type: IssueType; // New
   priority: IssuePriority;
   component?: string;
+  customer?: string;
   affectsVersion?: string; // New
   fixVersion?: string; // New
   projectId: string;
@@ -82,6 +83,9 @@ export interface Project {
   resolutions?: string[];
   types?: IssueType[];
   components?: string[];
+  customers?: string[];
+  showCustomers?: boolean;
+  showComponents?: boolean;
 }
 
 export const statusColors: Record<string, string> = {
@@ -126,6 +130,15 @@ export interface Version {
 }
 
 export interface Component {
+  id: string;
+  projectId: string;
+  name: string;
+  description?: string;
+  owners: string[];
+  issueCount?: number;
+}
+
+export interface Customer {
   id: string;
   projectId: string;
   name: string;


### PR DESCRIPTION
## Summary
- add customers feature alongside components
- toggle visibility of customers and components in new Project Details page
- support customer field in issue forms and issue APIs
- include customer collection and endpoints on the server

## Testing
- `npx tsc -p frontend-issue-tracker/tsconfig.json` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6864d470761c832eae271ee721f70be0