### PR TITLE
Enable editing on issue detail page

### DIFF
--- a/frontend-issue-tracker/src/IssueDetailPage.tsx
+++ b/frontend-issue-tracker/src/IssueDetailPage.tsx
@@ -1,26 +1,75 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { Issue } from './types';
+import type { IssueWithProject, Project, User } from './types';
 import { IssueDetailsView } from './components/IssueDetailsView';
+import { IssueForm } from './components/IssueForm';
+import { Modal } from './components/Modal';
+import type { IssueFormData } from './App';
 
 export const IssueDetailPage: React.FC = () => {
   const { issueKey } = useParams<{ issueKey: string }>();
-  const [issue, setIssue] = useState<Issue | null>(null);
+  const [issue, setIssue] = useState<IssueWithProject | null>(null);
+  const [project, setProject] = useState<Project | null>(null);
+  const [users, setUsers] = useState<User[]>([]);
   const [error, setError] = useState('');
+  const [showEdit, setShowEdit] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     const fetchIssue = async () => {
-      const res = await fetch(`/api/issues/key/${issueKey}`);
+      const res = await fetch(`/api/issuesWithProject/key/${issueKey}`);
       if (res.ok) {
-        const data: Issue = await res.json();
+        const data: IssueWithProject = await res.json();
         setIssue(data);
+        const projRes = await fetch(`/api/projects/${data.projectId}`);
+        if (projRes.ok) {
+          const proj: Project = await projRes.json();
+          setProject(proj);
+        }
+        const userRes = await fetch('/api/users');
+        if (userRes.ok) {
+          const us: User[] = await userRes.json();
+          setUsers(us);
+        }
       } else {
-        const err = await res.json().catch(() => ({ message: '이슈를 불러올 수 없습니다.' }));
+        const err = await res
+          .json()
+          .catch(() => ({ message: '이슈를 불러올 수 없습니다.' }));
         setError(err.message || '이슈를 불러올 수 없습니다.');
       }
     };
     fetchIssue();
   }, [issueKey]);
+
+  const handleEditIssue = async (formData: IssueFormData) => {
+    if (!issue) return;
+    setIsSubmitting(true);
+    setError('');
+    try {
+      const { attachments, ...rest } = formData;
+      const body = new FormData();
+      Object.entries(rest).forEach(([k, v]) => {
+        if (v !== undefined && v !== null) body.append(k, String(v));
+      });
+      (attachments || []).forEach((f) => body.append('files', f));
+      const res = await fetch(`/api/issues/${issue.id}`, {
+        method: 'PUT',
+        body,
+      });
+      if (res.ok) {
+        const updated: IssueWithProject = await res.json();
+        setIssue(updated);
+        setShowEdit(false);
+      } else {
+        const err = await res.json().catch(() => ({ message: '이슈 수정 실패' }));
+        setError(err.message || '이슈 수정 실패');
+      }
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   if (error) {
     return (
@@ -40,8 +89,47 @@ export const IssueDetailPage: React.FC = () => {
   return (
     <div className="p-6 space-y-4">
       <Link to="/" className="text-indigo-600 hover:underline">← Back</Link>
-      <h1 className="text-xl font-semibold">{issue.issueKey} - {issue.title}</h1>
-      <IssueDetailsView issue={issue} />
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">
+          {issue.issueKey} - {issue.title}
+        </h1>
+        <button
+          onClick={() => setShowEdit(true)}
+          className="px-3 py-1.5 text-sm rounded-md bg-indigo-600 text-white hover:bg-indigo-700"
+        >
+          Edit
+        </button>
+      </div>
+      <IssueDetailsView
+        issue={issue}
+        users={users}
+        showCustomers={issue.showCustomers}
+        showComponents={issue.showComponents}
+      />
+      <Modal isOpen={showEdit} onClose={() => setShowEdit(false)} title="이슈 수정">
+        {project && (
+          <IssueForm
+            onSubmit={handleEditIssue}
+            initialData={issue}
+            onCancel={() => setShowEdit(false)}
+            isSubmitting={isSubmitting}
+            submitButtonText="변경사항 저장"
+            isEditMode={true}
+            projects={[project]}
+            selectedProjectId={project.id}
+            users={users}
+            currentUserId={issue.reporter}
+            currentUserName={users.find(u => u.userid === issue.reporter)?.username || ''}
+            statuses={project.statuses || []}
+            priorities={project.priorities || []}
+            types={project.types || []}
+            components={project.components || []}
+            customers={project.customers || []}
+            showCustomers={project.showCustomers}
+            showComponents={project.showComponents}
+          />
+        )}
+      </Modal>
     </div>
   );
 };

--- a/frontend-issue-tracker/src/components/IssueDetailsView.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailsView.tsx
@@ -7,6 +7,8 @@ import { RichTextViewer } from './RichTextViewer';
 interface IssueDetailsViewProps {
   issue: Issue;
   users?: User[];
+  showCustomers?: boolean;
+  showComponents?: boolean;
 }
 
 interface DetailItemProps {
@@ -27,7 +29,12 @@ const DetailItem: React.FC<DetailItemProps> = ({ label, value, isCode, isPreLine
   </div>
 );
 
-export const IssueDetailsView: React.FC<IssueDetailsViewProps> = ({ issue, users }) => {
+export const IssueDetailsView: React.FC<IssueDetailsViewProps> = ({
+  issue,
+  users,
+  showCustomers = true,
+  showComponents = true,
+}) => {
   const formattedDate = new Date(issue.createdAt).toLocaleString('ko-KR', {
     year: 'numeric',
     month: 'long',
@@ -65,6 +72,18 @@ export const IssueDetailsView: React.FC<IssueDetailsViewProps> = ({ issue, users
         />
         <DetailItem label="등록자" value={users?.find(u => u.userid === issue.reporter)?.username || issue.reporter} />
         <DetailItem label="담당자" value={issue.assignee ? (users?.find(u => u.userid === issue.assignee)?.username || issue.assignee) : undefined} />
+        {showComponents && (
+          <DetailItem label="컴포넌트" value={issue.component} />
+        )}
+        {showCustomers && (
+          <DetailItem label="고객사" value={issue.customer} />
+        )}
+        {issue.affectsVersion && (
+          <DetailItem label="영향을 받는 버전" value={issue.affectsVersion} />
+        )}
+        {issue.fixVersion && (
+          <DetailItem label="수정 버전" value={issue.fixVersion} />
+        )}
         {issue.comments && issue.comments.length > 0 && (
           <div>
             <dt className="text-sm font-medium text-slate-500">코멘트</dt>

--- a/frontend-issue-tracker/src/types.ts
+++ b/frontend-issue-tracker/src/types.ts
@@ -47,6 +47,11 @@ export interface Issue {
   history?: IssueHistoryEntry[];
 }
 
+export interface IssueWithProject extends Issue {
+  showCustomers?: boolean;
+  showComponents?: boolean;
+}
+
 export interface Attachment {
   filename: string;
   originalName: string;


### PR DESCRIPTION
## Summary
- show/hide customer and component info on issue detail view
- load issue with project settings for show flags
- allow editing from IssueDetailPage using IssueForm
- extend Issue type with `IssueWithProject`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6865d0cbfb68832e893f4d278afdcd6b