### PR TITLE
Fix IssueDetailPanel to show type/priority names

### DIFF
--- a/frontend-issue-tracker/src/App.tsx
+++ b/frontend-issue-tracker/src/App.tsx
@@ -801,6 +801,14 @@ const App: React.FC = () => {
             projects.find((p) => p.id === selectedIssueForDetail.projectId)
               ?.statuses || []
           }
+          types={
+            projects.find((p) => p.id === selectedIssueForDetail.projectId)
+              ?.types || []
+          }
+          priorities={
+            projects.find((p) => p.id === selectedIssueForDetail.projectId)
+              ?.priorities || []
+          }
           showCustomers={currentProject?.showCustomers}
           showComponents={currentProject?.showComponents}
         />

--- a/frontend-issue-tracker/src/IssueDetailPage.tsx
+++ b/frontend-issue-tracker/src/IssueDetailPage.tsx
@@ -103,6 +103,9 @@ export const IssueDetailPage: React.FC = () => {
       <IssueDetailsView
         issue={issue}
         users={users}
+        statuses={project?.statuses || []}
+        types={project?.types || []}
+        priorities={project?.priorities || []}
         showCustomers={issue.showCustomers}
         showComponents={issue.showComponents}
       />

--- a/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailPanel.tsx
@@ -1,8 +1,21 @@
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import type { Issue, User, StatusItem } from "../types";
+import type {
+  Issue,
+  User,
+  StatusItem,
+  TypeItem,
+  PriorityItem,
+} from "../types";
 import type { ResolutionStatus } from "../types";
-import { statusColors, issueTypeColors } from "../types";
+import {
+  getStatusNameById,
+  getTypeNameById,
+  getPriorityNameById,
+  getStatusColorById,
+  getTypeColorById,
+  statusColors,
+} from "../types";
 import { PencilIcon } from "./icons/PencilIcon";
 import { TrashIcon } from "./icons/TrashIcon";
 import { XIcon } from "./icons/XIcon";
@@ -20,6 +33,8 @@ interface IssueDetailPanelProps {
   users: User[];
   onIssueUpdated: (issue: Issue) => void;
   statuses: (StatusItem | string)[];
+  types: (TypeItem | string)[];
+  priorities: (PriorityItem | string)[];
   showCustomers?: boolean;
   showComponents?: boolean;
 }
@@ -53,6 +68,8 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
   users,
   onIssueUpdated,
   statuses,
+  types,
+  priorities,
   showCustomers = true,
   showComponents = true,
 }) => {
@@ -86,6 +103,27 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
         minute: "2-digit",
       })
     : null;
+
+  const statusName = getStatusNameById(
+    issue.statusId || issue.status,
+    statuses as StatusItem[]
+  );
+  const statusColor = getStatusColorById(
+    issue.statusId || issue.status,
+    statuses as StatusItem[]
+  );
+  const typeName = getTypeNameById(
+    issue.typeId || issue.type,
+    types as TypeItem[]
+  );
+  const typeColor = getTypeColorById(
+    issue.typeId || issue.type,
+    types as TypeItem[]
+  );
+  const priorityName = getPriorityNameById(
+    issue.priorityId || issue.priority,
+    priorities as PriorityItem[]
+  );
 
   return (
     <>
@@ -135,13 +173,11 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
               label="상태"
               value={
                 <select
-                  value={issue.status}
+                  value={statusName}
                   onChange={(e) =>
                     onUpdateStatus(issue.id, e.target.value as ResolutionStatus)
                   }
-                  className={`w-full text-xs p-1.5 rounded-md border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 ${
-                    statusColors[issue.status]
-                  } appearance-none text-center font-medium`}
+                  className={`w-full text-xs p-1.5 rounded-md border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 ${statusColor} appearance-none text-center font-medium`}
                   aria-label="Update issue status"
                 >
                   {statuses.map((s) => {
@@ -165,15 +201,14 @@ export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = ({
               value={
                 <span
                   className={`px-2 py-0.5 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                    issueTypeColors[issue.type] ||
-                    "bg-slate-100 text-slate-800 ring-slate-600/20"
+                    typeColor || "bg-slate-100 text-slate-800 ring-slate-600/20"
                   }`}
                 >
-                  {issue.type}
+                  {typeName}
                 </span>
               }
             />
-            <DetailItem label="우선순위" value={issue.priority} />
+            <DetailItem label="우선순위" value={priorityName} />
             <DetailItem
               label="등록자"
               value={

--- a/frontend-issue-tracker/src/components/IssueDetailsView.tsx
+++ b/frontend-issue-tracker/src/components/IssueDetailsView.tsx
@@ -1,12 +1,31 @@
 
 import React from 'react';
-import type { Issue, User } from '../types';
-import { statusColors } from '../types';
+import type {
+  Issue,
+  User,
+  StatusItem,
+  TypeItem,
+  PriorityItem,
+} from '../types';
+import {
+  getStatusNameById,
+  getStatusColorById,
+  getTypeNameById,
+  getPriorityNameById,
+  getTypeColorById,
+  getPriorityColorById,
+  DEFAULT_STATUSES,
+  DEFAULT_ISSUE_TYPES,
+  DEFAULT_PRIORITIES,
+} from '../types';
 import { RichTextViewer } from './RichTextViewer';
 
 interface IssueDetailsViewProps {
   issue: Issue;
   users?: User[];
+  statuses?: (StatusItem | string)[];
+  types?: (TypeItem | string)[];
+  priorities?: (PriorityItem | string)[];
   showCustomers?: boolean;
   showComponents?: boolean;
 }
@@ -32,6 +51,9 @@ const DetailItem: React.FC<DetailItemProps> = ({ label, value, isCode, isPreLine
 export const IssueDetailsView: React.FC<IssueDetailsViewProps> = ({
   issue,
   users,
+  statuses = DEFAULT_STATUSES,
+  types = DEFAULT_ISSUE_TYPES,
+  priorities = DEFAULT_PRIORITIES,
   showCustomers = true,
   showComponents = true,
 }) => {
@@ -61,6 +83,15 @@ export const IssueDetailsView: React.FC<IssueDetailsViewProps> = ({
         second: '2-digit',
       })
     : null;
+
+  const statusName = getStatusNameById(
+    issue.statusId || issue.status,
+    statuses as StatusItem[]
+  );
+  const statusColor = getStatusColorById(
+    issue.statusId || issue.status,
+    statuses as StatusItem[]
+  );
 
   return (
     <div className="space-y-6">
@@ -125,9 +156,9 @@ export const IssueDetailsView: React.FC<IssueDetailsViewProps> = ({
           <dt className="text-sm font-medium text-slate-500">상태</dt>
           <dd className="mt-1">
             <span
-              className={`px-3 py-1 text-xs font-semibold rounded-full ring-1 ring-inset ${statusColors[issue.status]}`}
+              className={`px-3 py-1 text-xs font-semibold rounded-full ring-1 ring-inset ${statusColor}`}
             >
-              {issue.status}
+              {statusName}
             </span>
           </dd>
         </div>


### PR DESCRIPTION
## Summary
- display issue type and priority names instead of IDs in IssueDetailPanel
- pass type and priority info from App
- provide project metadata to IssueDetailsView and render status name

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` in frontend *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661a0a7124832eb7463bd2a2269a64